### PR TITLE
ci(build): add workflow for building the distribution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Sec
+
+on:
+  push:
+    branches: '**'
+
+permissions:
+  contents: write
+
+jobs:
+  sec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: |
+          make build-dependencies
+      - name: Build Distribution
+        run: |
+          make build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Sec
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 jobs:
-  sec:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # containerimage-py
 
-[![Test](https://github.com/containers/containerimage-py/actions/workflows/test.yaml/badge.svg)](https://github.com/containers/containerimage-py/actions/workflows/test.yaml) [![Sec](https://github.com/containers/containerimage-py/actions/workflows/sec.yaml/badge.svg)](https://github.com/containers/containerimage-py/actions/workflows/sec.yaml) [![Doc](https://github.com/containers/containerimage-py/actions/workflows/doc.yaml/badge.svg)](https://github.com/containers/containerimage-py/actions/workflows/doc.yaml)
+[![Test](https://github.com/containers/containerimage-py/actions/workflows/test.yaml/badge.svg)](https://github.com/containers/containerimage-py/actions/workflows/test.yaml) [![Sec](https://github.com/containers/containerimage-py/actions/workflows/sec.yaml/badge.svg)](https://github.com/containers/containerimage-py/actions/workflows/sec.yaml) [![Doc](https://github.com/containers/containerimage-py/actions/workflows/doc.yaml/badge.svg)](https://github.com/containers/containerimage-py/actions/workflows/doc.yaml) [![Build](https://github.com/containers/containerimage-py/actions/workflows/build.yaml/badge.svg)](https://github.com/containers/containerimage-py/actions/workflows/build.yaml)
 
 A python library for interacting with container images and container image registries
 


### PR DESCRIPTION
In this PR, I add a workflow for building the python wheel for this project on each commit.  This will help us ensure the distribution actually builds and doesn't fail out due to some change that was made along the way.  This was mentioned in issue
- https://github.com/containers/containerimage-py/issues/10

but there was no specific sub-issue planned for it, so I'm covering this now before closing out that overarching issue.