### PR TITLE
doc(release): remove pip install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ python3 examples/quick-example.py
 
 ### Using Pip
 
-> IMPORTANT: This project has not yet been released on PyPi.  This will not work at this point in time.  Instead follow [the local install instructions](#installation).
-
 Run the following command to install the latest version of this package
 
 ```

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -42,8 +42,6 @@ Installation
 
 **Using Pip**
 
-   IMPORTANT: This project has not yet been released on PyPi.  This will not work at this point in time.  Instead follow the local install instructions.
-
 Run the following command to install the latest version of this package using pip
 
 .. code-block:: shell


### PR DESCRIPTION
In this PR, I remove the note in the README and docs indicating that the package is not yet published on pip.  I do so in anticipation of the release of `v1.0.0-alpha.1`.

For reference, see:
- https://github.com/containers/containerimage-py/issues/19