### PR TITLE
fix(auth): do auth dance even when basic auth creds are not found

### DIFF
--- a/image/client.py
+++ b/image/client.py
@@ -139,7 +139,7 @@ class ContainerImageRegistryClient:
         response, and MUST include the www-authenticate header
 
         Args:
-            res (Type[requests.Response]): The response from the registry API
+            res (requests.Response): The response from the registry API
             reg_auth (str): The auth retrieved for the registry
 
         Returns:
@@ -168,9 +168,11 @@ class ContainerImageRegistryClient:
 
         # Send the request to the auth service, parse the token from the
         # response
-        headers = {
-            'Authorization': f"Basic {reg_auth}"
-        }
+        headers = {}
+        if len(reg_auth) > 0:
+            headers = {
+                'Authorization': f"Basic {reg_auth}"
+            }
         token_res = requests.get(auth_url, headers=headers)
         token_res.raise_for_status()
         token_json = token_res.json()

--- a/image/client.py
+++ b/image/client.py
@@ -219,7 +219,7 @@ class ContainerImageRegistryClient:
         # Send the request to the distribution registry API
         # If it fails with a 401 response code and auth given, do OAuth dance
         res = requests.get(api_url, headers=headers)
-        if res.status_code == 401 and found and \
+        if res.status_code == 401 and \
             'www-authenticate' in res.headers.keys():
             # Do Oauth dance if basic auth fails
             # Ref: https://distribution.github.io/distribution/spec/auth/token/
@@ -308,7 +308,7 @@ class ContainerImageRegistryClient:
         # Send the request to the distribution registry API
         # If it fails with a 401 response code and auth given, do OAuth dance
         res = requests.get(api_url, headers=headers)
-        if res.status_code == 401 and found and \
+        if res.status_code == 401 and \
             'www-authenticate' in res.headers.keys():
             # Do Oauth dance if basic auth fails
             # Ref: https://distribution.github.io/distribution/spec/auth/token/
@@ -433,7 +433,7 @@ class ContainerImageRegistryClient:
         # Send the request to the distribution registry API
         # If it fails with a 401 response code and auth given, do OAuth dance
         res = requests.delete(api_url, headers=headers)
-        if res.status_code == 401 and found and \
+        if res.status_code == 401 and \
             'www-authenticate' in res.headers.keys():
             # Do Oauth dance if basic auth fails
             # Ref: https://distribution.github.io/distribution/spec/auth/token/


### PR DESCRIPTION
> [!NOTE]
> Cherry-pick of:
> - https://github.com/containers/containerimage-py/pull/31

In this PR, I remove the `found` condition from the if statement around the auth dances performed to fetch a token from the registry auth server.  This condition required that the user provide basic auth creds in their initial request only for those creds to then fail on the initial request, with a 401 response sent back and a `www-authenticate` header instructing the client to fetch a token from the auth server.  Some registries (such as `ghcr.io`) require this dance for all clients regardless of whether the image is public or private.  Removing this condition seems to work now for public `ghcr.io` images.

For reference, see:
- https://github.com/containers/containerimage-py/issues/30