### PR TITLE
feat(inspect): implement python-native skopeo inspect

### DIFF
--- a/examples/image-inspect.py
+++ b/examples/image-inspect.py
@@ -1,0 +1,27 @@
+######
+# Hack
+#
+# Make sibling modules visible to this nested executable
+import os, sys
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.realpath(__file__)
+        )
+    )
+)
+# End Hack
+######
+
+from image.containerimage import ContainerImage
+
+# Initialize a ContainerImage given a tag reference
+my_image = ContainerImage("registry.k8s.io/pause:3.5")
+
+# Display the inspect information for the container image
+my_image_inspect = my_image.inspect(auth={})
+print(
+    f"Inspect of {str(my_image)}: \n" + \
+    str(my_image_inspect)
+)

--- a/image/config.py
+++ b/image/config.py
@@ -3,7 +3,7 @@ Contains the ContainerImageConfig class, which specifies the runtime
 configuration for a container image.
 """
 
-from typing import Dict, Any, Tuple, Type, Union
+from typing import Dict, Any, Tuple, Type, Union, List
 from jsonschema import validate, ValidationError
 from image.configschema import CONTAINER_IMAGE_CONFIG_SCHEMA
 from image.platform import ContainerImagePlatform
@@ -106,3 +106,49 @@ class ContainerImageConfig:
         if variant != None:
             platform_dict["variant"] = variant
         return ContainerImagePlatform(platform_dict)
+    
+    def get_labels(self) -> Dict[str, str]:
+        """
+        Returns the container image labels from the config
+
+        Returns:
+            Dict[str, str]: The labels from the config
+        """
+        return self.config.get("Labels", {})
+
+    def get_created_date(self) -> str:
+        """
+        Returns the created date of the container image from the config
+
+        Returns:
+            str: The created date, as a string
+        """
+        return self.config.get("created", "")
+
+    def get_runtime_config(self) -> Dict[str, Any]:
+        """
+        Returns the runtime config for the container image from its config
+
+        Returns:
+            Dict[str, Any]: The container image runtime config
+        """
+        return self.config.get("config", {})
+
+    def get_env(self) -> List[str]:
+        """
+        Returns the list of environment variables set for the container image
+        at build time from the container image runtime config
+
+        Returns:
+            List[str]: The list of environment variables
+        """
+        return self.get_runtime_config().get("Env", [])
+
+    def get_author(self) -> str:
+        """
+        Returns the author of the container image from its config
+
+        Returns:
+            str: The container image author
+        """
+        return self.config.get("Author", "")

--- a/image/config.py
+++ b/image/config.py
@@ -114,7 +114,7 @@ class ContainerImageConfig:
         Returns:
             Dict[str, str]: The labels from the config
         """
-        return self.config.get("Labels", {})
+        return self.get_runtime_config().get("Labels", {})
 
     def get_created_date(self) -> str:
         """
@@ -151,4 +151,4 @@ class ContainerImageConfig:
         Returns:
             str: The container image author
         """
-        return self.config.get("Author", "")
+        return self.config.get("author", "")

--- a/image/containerimage.py
+++ b/image/containerimage.py
@@ -9,20 +9,21 @@ metadata and mutating the image through the registry API.
 from __future__ import annotations
 import json
 import requests
-from typing                 import  List, Dict, Any, \
-                                    Union, Type, Iterator
-from image.byteunit         import  ByteUnit
-from image.client           import  ContainerImageRegistryClient
-from image.config           import  ContainerImageConfig
-from image.errors           import  ContainerImageError
-from image.manifestfactory  import  ContainerImageManifestFactory
-from image.manifestlist     import  ContainerImageManifestList
-from image.oci              import  ContainerImageManifestOCI, \
-                                    ContainerImageIndexOCI
-from image.platform         import  ContainerImagePlatform
-from image.reference        import  ContainerImageReference
-from image.v2s2             import  ContainerImageManifestV2S2, \
-                                    ContainerImageManifestListV2S2
+from typing                         import  List, Dict, Any, \
+                                            Union, Type, Iterator
+from image.byteunit                 import  ByteUnit
+from image.client                   import  ContainerImageRegistryClient
+from image.config                   import  ContainerImageConfig
+from image.containerimageinspect    import  ContainerImageInspect
+from image.errors                   import  ContainerImageError
+from image.manifestfactory          import  ContainerImageManifestFactory
+from image.manifestlist             import  ContainerImageManifestList
+from image.oci                      import  ContainerImageManifestOCI, \
+                                            ContainerImageIndexOCI
+from image.platform                 import  ContainerImagePlatform
+from image.reference                import  ContainerImageReference
+from image.v2s2                     import  ContainerImageManifestV2S2, \
+                                            ContainerImageManifestListV2S2
 
 #########################################
 # Classes for managing container images #
@@ -85,6 +86,103 @@ class ContainerImage(ContainerImageReference):
         return isinstance(manifest, ContainerImageManifestOCI) or \
                 isinstance(manifest, ContainerImageIndexOCI)
     
+    @staticmethod
+    def get_host_platform_manifest_static(
+            ref: ContainerImageReference,
+            manifest: Union[
+                ContainerImageManifestV2S2,
+                ContainerImageManifestListV2S2,
+                ContainerImageManifestOCI,
+                ContainerImageIndexOCI
+            ],
+            auth: Dict[str, Any]
+        ) -> Union[
+            ContainerImageManifestV2S2,
+            ContainerImageManifestOCI
+        ]:
+        """
+        Given an image's reference and manifest, this static method checks if
+        the manifest is a manifest list, and attempts to get the manifest from
+        the list matching the host platform.
+
+        Args:
+            ref (ContainerImageReference): The image reference corresponding to the manifest
+            manifest (Union[ContainerImageManifestV2S2,ContainerImageManifestListV2S2,ContainerImageManifestOCI,ContainerImageIndexOCI]): The manifest object, generally from get_manifest method
+            auth (Dict[str, Any]): A valid docker config JSON with auth into the ref's registry
+        
+        Returns:
+            Union[ContainerImageManifestV2S2,ContainerImageManifestOCI]: The manifest response from the registry API
+
+        Raises:
+            ContainerImageError: Error if the image is a manifest list without a manifest matching the host platform
+        """
+        host_manifest = manifest
+
+        # If manifest list, get the manifest matching the host platform
+        if ContainerImage.is_manifest_list_static(manifest):
+            found = False
+            host_entry_digest = None
+            host_plt = ContainerImagePlatform.get_host_platform()
+            entries = manifest.get_entries()
+            for entry in entries:
+                if entry.get_platform() == host_plt:
+                    found = True
+                    host_entry_digest = entry.get_digest()
+            if not found:
+                raise ContainerImageError(
+                    "no image found in manifest list for platform: " + \
+                    f"{str(host_plt)}"
+                )
+            host_ref = ContainerImage(
+                f"{ref.get_name()}@{host_entry_digest}"
+            )
+            host_manifest = host_ref.get_manifest(auth=auth)
+        
+        # Return the manifest matching the host platform
+        return host_manifest
+
+    @staticmethod
+    def get_config_static(
+            ref: ContainerImageReference,
+            manifest: Union[
+                ContainerImageManifestV2S2,
+                ContainerImageManifestListV2S2,
+                ContainerImageManifestOCI,
+                ContainerImageIndexOCI
+            ],
+            auth: Dict[str, Any]
+        ) -> ContainerImageConfig:
+        """
+        Given an image's manifest, this static method fetches that image's
+        config from the distribution registry API.  If the image is a manifest
+        list, then it gets the config corresponding to the manifest matching
+        the host platform.
+
+        Args:
+            ref (ContainerImageReference): The image reference corresponding to the manifest
+            manifest (Union[ContainerImageManifestV2S2,ContainerImageManifestListV2S2,ContainerImageManifestOCI,ContainerImageIndexOCI]): The manifest object, generally from get_manifest method
+            auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+        
+        Returns:
+            ContainerImageConfig: The config for this image
+
+        Raises:
+            ContainerImageError: Error if the image is a manifest list without a manifest matching the host platform
+        """
+        # If manifest list, get the manifest matching the host platform
+        manifest = ContainerImage.get_host_platform_manifest_static(
+            ref, manifest, auth
+        )
+        
+        # Get the image's config
+        return ContainerImageConfig(
+            ContainerImageRegistryClient.get_config(
+                ref,
+                manifest.get_config_descriptor(),
+                auth=auth
+            )
+        )
+
     def __init__(self, ref: str):
         """
         Constructor for the ContainerImage class
@@ -179,6 +277,61 @@ class ContainerImage(ContainerImageReference):
             ContainerImageRegistryClient.get_manifest(self, auth)
         )
     
+    def get_host_platform_manifest(self, auth: Dict[str, Any]) -> Union[
+            ContainerImageManifestOCI,
+            ContainerImageManifestV2S2
+        ]:
+        """
+        Fetches the manifest from the distribution registry API.  If the
+        manifest is a manifest list, then it attempts to fetch the manifest
+        in the list matching the host platform.  If not found, an exception is
+        raised.
+
+        Args:
+            auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+        
+        Returns:
+            Union[ContainerImageManifestV2S2,ContainerImageManifestOCI]: The manifest response from the registry API
+
+        Raises:
+            ContainerImageError: Error if the image is a manifest list without a manifest matching the host platform
+        """
+        # Get the container image's manifest
+        manifest = self.get_manifest(auth=auth)
+        
+        # Return the host platform manifest
+        return ContainerImage.get_host_platform_manifest_static(
+            self,
+            manifest,
+            auth
+        )
+
+    def get_config(self, auth: Dict[str, Any]) -> ContainerImageConfig:
+        """
+        Fetches the image's config from the distribution registry API.  If the
+        image is a manifest list, then it gets the config corresponding to the
+        manifest matching the host platform.
+
+        Args:
+            auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+        
+        Returns:
+            ContainerImageConfig: The config for this image
+
+        Raises:
+            ContainerImageError: Error if the image is a manifest list without a manifest matching the host platform
+        """
+        # Get the image's manifest
+        manifest = self.get_manifest(auth=auth)
+
+        # Use the image's manifest to get the image's config
+        config = ContainerImage.get_config_static(
+            self, manifest, auth
+        )
+
+        # Return the image's config
+        return config
+
     def exists(self, auth: Dict[str, Any]) -> bool:
         """
         Determine if the image reference corresponds to an image in the remote
@@ -266,6 +419,60 @@ class ContainerImage(ContainerImageReference):
         """
         return ByteUnit.format_size_bytes(self.get_size(auth))
     
+    def inspect(self, auth: Dict[str, Any]) -> ContainerImageInspect:
+        """
+        Returns a collection of basic information about the image, equivalent
+        to skopeo inspect.
+
+        Args:
+            auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+        
+        Returns:
+            ContainerImageInspect: A collection of information about the image
+        """
+        # Get the image's manifest
+        manifest = self.get_host_platform_manifest(auth=auth)
+
+        # Use the image's manifest to get the image's config
+        config = ContainerImage.get_config_static(
+            self, manifest, auth
+        )
+
+        # Format the inspect dictionary
+        inspect = {
+            "Name": self.get_name(),
+            "Digest": self.get_digest(auth=auth),
+            # TODO: Implement v2s1 manifest extension - only v2s1 manifests use this value
+            "DockerVersion": "",
+            "Created": config.get_created_date(),
+            "Labels": config.get_labels(),
+            "Architecture": config.get_architecture(),
+            "Variant": config.get_variant() or "",
+            "Os": config.get_os(),
+            "Layers": [ 
+                layer.get_digest() \
+                for layer \
+                in manifest.get_layer_descriptors()
+            ],
+            "LayersData": [
+                {
+                    "MIMEType": layer.get_media_type(),
+                    "Digest": layer.get_digest(),
+                    "Size": layer.get_size(),
+                    "Annotations": layer.get_annotations() or {}
+                } for layer in manifest.get_layer_descriptors()
+            ],
+            "Env": config.get_env(),
+            "Author": config.get_author()
+        }
+
+        # Set the tag in the inspect dict
+        if self.is_tag_ref():
+            inspect["Tag"] = self.get_identifier()
+        
+        # TODO: Get the RepoTags for the image
+        return ContainerImageInspect(inspect)
+
     def delete(self, auth: Dict[str, Any]):
         """
         Deletes the image from the registry.

--- a/image/containerimage.py
+++ b/image/containerimage.py
@@ -332,6 +332,18 @@ class ContainerImage(ContainerImageReference):
         # Return the image's config
         return config
 
+    def list_tags(self, auth: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Fetches the list of tags for the image from the distribution registry
+        API.
+        Args:
+            auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+        
+        Returns:
+            Dict[str, Any]: The tag list loaded into a dict
+        """
+        return ContainerImageRegistryClient.list_tags(self, auth)
+
     def exists(self, auth: Dict[str, Any]) -> bool:
         """
         Determine if the image reference corresponds to an image in the remote
@@ -438,10 +450,14 @@ class ContainerImage(ContainerImageReference):
             self, manifest, auth
         )
 
+        # List the image's tags
+        tags = self.list_tags(auth)
+
         # Format the inspect dictionary
         inspect = {
             "Name": self.get_name(),
             "Digest": self.get_digest(auth=auth),
+            "RepoTags": tags["tags"],
             # TODO: Implement v2s1 manifest extension - only v2s1 manifests use this value
             "DockerVersion": "",
             "Created": config.get_created_date(),

--- a/image/containerimage.py
+++ b/image/containerimage.py
@@ -463,7 +463,6 @@ class ContainerImage(ContainerImageReference):
             "Created": config.get_created_date(),
             "Labels": config.get_labels(),
             "Architecture": config.get_architecture(),
-            "Variant": config.get_variant() or "",
             "Os": config.get_os(),
             "Layers": [ 
                 layer.get_digest() \
@@ -478,9 +477,13 @@ class ContainerImage(ContainerImageReference):
                     "Annotations": layer.get_annotations() or {}
                 } for layer in manifest.get_layer_descriptors()
             ],
-            "Env": config.get_env(),
-            "Author": config.get_author()
+            "Env": config.get_env()
         }
+
+        # Set the variant in the inspect dict if found
+        variant = config.get_variant()
+        if variant:
+            inspect["Variant"] = variant
 
         # Set the tag in the inspect dict
         if self.is_tag_ref():

--- a/image/containerimageinspect.py
+++ b/image/containerimageinspect.py
@@ -1,0 +1,81 @@
+import json
+from image.errors import ContainerImageError
+from image.inspectschema import CONTAINER_IMAGE_INSPECT_SCHEMA
+from jsonschema import validate
+from typing import Dict, Any, Tuple
+
+class ContainerImageInspect:
+    """
+    Represents a collection of basic informataion about a container image.
+    This object is equivalent to the output of skopeo inspect.
+    """
+    @staticmethod
+    def validate_static(inspect: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Validate a container image inspect dict using its json schema
+
+        Args:
+            inspect (dict): The container image inspect dict to validate
+
+        Returns:
+            bool: Whether the container image inspect dict was valid
+            str: Error message if it was invalid
+        """
+        # Validate the container image inspect dict
+        try:
+            validate(
+                instance=inspect,
+                schema=CONTAINER_IMAGE_INSPECT_SCHEMA
+            )
+        except Exception as e:
+            return False, str(e)
+        return True, ""
+
+    def __init__(self, inspect: Dict[str, Any]) -> "ContainerImageInspect":
+        """
+        Constructor for the ContainerImageInspect class
+
+        Args:
+            inspect (dict): The container image inspect dict
+
+        Returns:
+            ContainerImageInspect: The ContainerImageInspect instance
+        """
+        valid, err = ContainerImageInspect.validate_static(inspect)
+        if not valid:
+            raise ContainerImageError(f"Invalid inspect dictionary: {err}")
+        self.inspect = inspect
+
+    def validate(self) -> Tuple[bool, str]:
+        """
+        Validate a container image inspect instance
+
+        Returns:
+            bool: Whether the container image inspect dict was valid
+            str: Error message if it was invalid
+        """
+        return ContainerImageInspect.validate_static(self.inspect)
+
+    def __str__(self) -> str:
+        """
+        Stringifies a ContainerImageInspect instance
+
+        Args:
+        None
+
+        Returns:
+        str: The stringified inspect
+        """
+        return json.dumps(self.inspect, indent=2, sort_keys=False)
+
+    def __json__(self) -> Dict[str, Any]:
+        """
+        JSONifies a ContainerImageInspect instance
+
+        Args:
+        None
+
+        Returns:
+        Dict[str, Any]: The JSONified descriptor
+        """
+        return self.inspect

--- a/image/inspectschema.py
+++ b/image/inspectschema.py
@@ -61,7 +61,14 @@ CONTAINER_IMAGE_INSPECT_SCHEMA = {
             "description": "This OPTIONAL property is the tag of this " + \
                 "container image"
         },
-        # TODO: Add RepoTags property
+        "RepoTags": {
+            "type": "array",
+            "description": "This OPTIONAL property is the list of tags " + \
+                "for this container image in the remote registry",
+            "items": {
+                "type": "string"
+            }
+        },
         "Created": {
             "type": "string",
             "description": "This REQUIRED property is the date this " + \

--- a/image/inspectschema.py
+++ b/image/inspectschema.py
@@ -1,0 +1,135 @@
+CONTAINER_IMAGE_LAYER_INSPECT_SCHEMA = {
+    "type": "object",
+    "description": "The JSON schema for a container image layer inspect " + \
+        "dictionary.",
+    "required": [ "MIMEType", "Digest", "Size" ],
+    "additionalProperties": False,
+    "properties": {
+        "MIMEType": {
+            "type": "string",
+            "description": "This REQUIRED property is the MIME type, or " + \
+                "media type, of this container image layer"
+        },
+        "Digest": {
+            "type": "string",
+            "description": "This REQUIRED property is the digest of this " + \
+                "container image layer"
+        },
+        "Size": {
+            "type": "integer",
+            "description": "This REQUIRED property is the size of this " + \
+                "container image layer measured in bytes"
+        },
+        "Annotations": {
+            "type": "object",
+            "description": "This OPTIONAL property is the set of " + \
+                "annotations belonging to this container image",
+            "patternProperties": {
+                "(^.*$)": { "type": "string" }
+            }
+        }
+    }
+}
+"""
+The JSON schema for validating a container image layer inspect dictionary
+Ref: https://github.com/containers/image/blob/main/types/types.go#L491-L497
+
+:meta hide-value:
+"""
+
+CONTAINER_IMAGE_INSPECT_SCHEMA = {
+    "type": "object",
+    "description": "The JSON schema for a container image inspect dictionary",
+    "required": [ 
+        "Digest", "Created", "DockerVersion", "Labels", "Architecture", "Os",
+        "Layers", "LayersData", "Env"
+    ],
+    "additionalProperties": False,
+    "properties": {
+        "Name": {
+            "type": "string",
+            "description": "This OPTIONAL property is the name of this " + \
+                "container image"
+        },
+        "Digest": {
+            "type": "string",
+            "description": "This REQUIRED property is the digest of this " + \
+                "container image"
+        },
+        "Tag": {
+            "type": "string",
+            "description": "This OPTIONAL property is the tag of this " + \
+                "container image"
+        },
+        # TODO: Add RepoTags property
+        "Created": {
+            "type": "string",
+            "description": "This REQUIRED property is the date this " + \
+                "container image was built"
+        },
+        "DockerVersion": {
+            "type": "string",
+            "description": "This REQUIRED property is the version of " + \
+                "docker used to build this container image"
+        },
+        "Labels": {
+            "type": "object",
+            "description": "This REQUIRED property is the set of labels " + \
+                "applied to this container image at build time",
+            "patternProperties": {
+                "(^.*$)": { "type": "string" }
+            }
+        },
+        "Architecture": {
+            "type": "string",
+            "description": "This REQUIRED property is the architecture " + \
+                "for which this container image was built"
+        },
+        "Variant": {
+            "type": "string",
+            "description": "This OPTIONAL property is the variant of the " + \
+                "OS and architecture for which this container image was built"
+        },
+        "Os": {
+            "type": "string",
+            "description": "This REQUIRED property is the operating system" + \
+                "for which this container image was built"
+        },
+        "Layers": {
+            "type": "array",
+            "description": "This REQUIRED property contains information " + \
+                "on the set of layers belonging to this container image",
+            "items": {
+                "type": "string"
+            }
+        },
+        "LayersData": {
+            "type": "array",
+            "description": "This REQUIRED property contains information " + \
+                "on the set of layers belonging to this container image",
+            "items": CONTAINER_IMAGE_LAYER_INSPECT_SCHEMA
+        },
+        "Env": {
+            "type": "array",
+            "description": "This REQUIRED property contains information " + \
+                "on the set of environment variables set at build time " + \
+                "in this container image",
+            "items": {
+                "type": "string"
+            }
+        },
+        "Author": {
+            "type": "string",
+            "description": "This OPTIONAL property is the author who " + \
+                "built the container image"
+        }
+    }
+}
+"""
+The JSON schema for validating a container image inspect dictionary
+Ref:
+- https://github.com/containers/image/blob/main/types/types.go#L474-L489
+- https://github.com/containers/image/blob/main/types/types.go#L474-L489
+
+:meta hide-value:
+"""

--- a/image/inspectschema.py
+++ b/image/inspectschema.py
@@ -21,12 +21,19 @@ CONTAINER_IMAGE_LAYER_INSPECT_SCHEMA = {
                 "container image layer measured in bytes"
         },
         "Annotations": {
-            "type": "object",
-            "description": "This OPTIONAL property is the set of " + \
-                "annotations belonging to this container image",
-            "patternProperties": {
-                "(^.*$)": { "type": "string" }
-            }
+            "anyOf": [
+                {
+                    "type": "object",
+                    "description": "This OPTIONAL property is the set of " + \
+                        "annotations belonging to this container image",
+                    "patternProperties": {
+                        "(^.*$)": { "type": "string" }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
     }
 }
@@ -80,12 +87,19 @@ CONTAINER_IMAGE_INSPECT_SCHEMA = {
                 "docker used to build this container image"
         },
         "Labels": {
-            "type": "object",
-            "description": "This REQUIRED property is the set of labels " + \
-                "applied to this container image at build time",
-            "patternProperties": {
-                "(^.*$)": { "type": "string" }
-            }
+            "anyOf": [
+                {
+                    "type": "object",
+                    "description": "This REQUIRED property is the set of labels " + \
+                        "applied to this container image at build time",
+                    "patternProperties": {
+                        "(^.*$)": { "type": "string" }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         },
         "Architecture": {
             "type": "string",

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,89 @@
+import copy
+import json
+import os
+from image.config import ContainerImageConfig
+from typing import Dict, Any
+
+# Get the directory of this file to load the JSON schemas from files
+WORKDIR = os.path.dirname(os.path.realpath(__file__))
+
+def _load_json(path: str) -> Dict[str, Any]:
+    """
+    Helper function for loading mock manifests
+    """
+    mock_manifest_dict = {}
+    with open(path) as mock_manifest_file:
+        mock_manifest_dict = json.load(mock_manifest_file)
+    return mock_manifest_dict
+
+EXAMPLE_CONFIG = _load_json(f"{WORKDIR}/mock/configs/config.json")
+
+def test_load_config():
+    """
+    Ensure we can load a config from the OCI image spec
+    """
+    exc = None
+    try:
+        inspect = ContainerImageConfig(EXAMPLE_CONFIG)
+    except Exception as e:
+        exc = e
+    assert exc == None
+    assert isinstance(inspect, ContainerImageConfig)
+
+def test_load_config_no_platform():
+    """
+    Ensure the config fails to load if no OS or arch given
+    """
+    # No os
+    conf = copy.deepcopy(EXAMPLE_CONFIG)
+    conf.pop("os")
+    exc = None
+    try:
+        config = ContainerImageConfig(conf)
+    except Exception as e:
+        exc = e
+    assert exc != None
+
+    # No architecture
+    conf = copy.deepcopy(EXAMPLE_CONFIG)
+    conf.pop("architecture")
+    exc = None
+    try:
+        config = ContainerImageConfig(conf)
+    except Exception as e:
+        exc = e
+    assert exc != None
+
+def test_load_config_no_rootfs():
+    """
+    Ensure the config fails to load if no rootfs property given
+    """
+    # No rootfs property at all
+    conf = copy.deepcopy(EXAMPLE_CONFIG)
+    conf.pop("rootfs")
+    exc = None
+    try:
+        config = ContainerImageConfig(conf)
+    except Exception as e:
+        exc = e
+    assert exc != None
+
+    # No type in rootfs property
+    conf = copy.deepcopy(EXAMPLE_CONFIG)
+    conf["rootfs"].pop("type")
+    exc = None
+    try:
+        config = ContainerImageConfig(conf)
+    except Exception as e:
+        exc = e
+    assert exc != None
+
+    # No diff_ids in rootfs property
+    conf = copy.deepcopy(EXAMPLE_CONFIG)
+    conf["rootfs"].pop("diff_ids")
+    exc = None
+    try:
+        config = ContainerImageConfig(conf)
+    except Exception as e:
+        exc = e
+    assert exc != None

--- a/tests/containerimage_test.py
+++ b/tests/containerimage_test.py
@@ -1,25 +1,28 @@
 import json
-from image.byteunit             import  ByteUnit
-from image.errors               import  ContainerImageError
-from image.v2s2                 import  ContainerImageManifestV2S2
-from image.oci                  import  ContainerImageManifestOCI
-from image.containerimage       import  ContainerImage, \
-                                        ContainerImageManifestListV2S2, \
-                                        ContainerImageIndexOCI
-from tests.registryclientmock   import  MOCK_IMAGE_NAME, \
-                                        MOCK_REGISTRY_CREDS, \
-                                        REDHAT_MANIFEST_LIST_EXAMPLE, \
-                                        REDHAT_AMD64_MANIFEST, \
-                                        REDHAT_ARM64_MANIFEST, \
-                                        REDHAT_PPC64LE_MANIFEST, \
-                                        REDHAT_S390X_MANIFEST, \
-                                        ATTESTATION_MANIFEST_LIST_EXAMPLE, \
-                                        ATTESTATION_AMD64_MANIFEST, \
-                                        ATTESTATION_S390X_MANIFEST, \
-                                        ATTESTATION_AMD64_ATTESTATION_MANIFEST, \
-                                        ATTESTATION_S390X_ATTESTATION_MANIFEST, \
-                                        mock_get_manifest, \
-                                        mock_list_tags
+from image.byteunit                 import  ByteUnit
+from image.errors                   import  ContainerImageError
+from image.v2s2                     import  ContainerImageManifestV2S2
+from image.oci                      import  ContainerImageManifestOCI
+from image.containerimage           import  ContainerImage, \
+                                            ContainerImageManifestListV2S2, \
+                                            ContainerImageIndexOCI
+from image.containerimageinspect    import ContainerImageInspect
+from tests.registryclientmock       import  MOCK_IMAGE_NAME, \
+                                            MOCK_REGISTRY_CREDS, \
+                                            REDHAT_MANIFEST_LIST_EXAMPLE, \
+                                            REDHAT_AMD64_MANIFEST, \
+                                            REDHAT_ARM64_MANIFEST, \
+                                            REDHAT_PPC64LE_MANIFEST, \
+                                            REDHAT_S390X_MANIFEST, \
+                                            ATTESTATION_MANIFEST_LIST_EXAMPLE, \
+                                            ATTESTATION_AMD64_MANIFEST, \
+                                            ATTESTATION_S390X_MANIFEST, \
+                                            ATTESTATION_AMD64_ATTESTATION_MANIFEST, \
+                                            ATTESTATION_S390X_ATTESTATION_MANIFEST, \
+                                            mock_get_manifest, \
+                                            mock_list_tags, \
+                                            mock_get_config, \
+                                            mock_get_digest
 
 def test_container_image_static_validation():
     # Ensure the empty string is invalid
@@ -302,6 +305,42 @@ def test_container_image_get_manifest(mocker):
         exc = e
     assert exc != None
     assert isinstance(exc, ContainerImageError)
+
+def test_container_image_inspect(mocker):
+    mocker.patch(
+        "image.containerimage.ContainerImageRegistryClient.get_manifest",
+        mock_get_manifest
+    )
+    mocker.patch(
+        "image.containerimage.ContainerImageRegistryClient.list_tags",
+        mock_list_tags
+    )
+    mocker.patch(
+        "image.containerimage.ContainerImageRegistryClient.get_config",
+        mock_get_config
+    )
+    mocker.patch(
+        "image.containerimage.ContainerImageRegistryClient.get_digest",
+        mock_get_digest
+    )
+    image = ContainerImage(f"{MOCK_IMAGE_NAME}:latest")
+
+    # Ensure the inspect response matches the expected
+    exc = None
+    try:
+        inspect = image.inspect(MOCK_REGISTRY_CREDS)
+    except Exception as e:
+        exc = e
+    assert exc == None
+    assert isinstance(inspect, ContainerImageInspect)
+    assert inspect.inspect["Digest"] == "sha256:8f74ffc756f871ee9037fb8e0c3cd9c5cb54e92e014f92d771ab8e6bf925f372"
+    assert inspect.inspect["RepoTags"] == [ "latest", "latest-dup", "latest-attestation" ]
+    assert inspect.inspect["Created"] == "2015-10-31T22:22:56.015925234Z"
+    assert inspect.inspect["Labels"] == {
+        "com.example.project.git.url": "https://example.com/project.git",
+        "com.example.project.git.commit": "45a939b2999782a3f005621a8d0f29aa387e1d6b"
+    }
+    assert inspect.inspect["Author"] == "Alyssa P. Hacker <alyspdev@example.com>"
 
 def test_container_image_is_manifest_list(mocker):
     mocker.patch(

--- a/tests/containerimage_test.py
+++ b/tests/containerimage_test.py
@@ -18,7 +18,8 @@ from tests.registryclientmock   import  MOCK_IMAGE_NAME, \
                                         ATTESTATION_S390X_MANIFEST, \
                                         ATTESTATION_AMD64_ATTESTATION_MANIFEST, \
                                         ATTESTATION_S390X_ATTESTATION_MANIFEST, \
-                                        mock_get_manifest
+                                        mock_get_manifest, \
+                                        mock_list_tags
 
 def test_container_image_static_validation():
     # Ensure the empty string is invalid
@@ -249,6 +250,18 @@ def test_container_image_get_name():
         exc = e
     assert exc != None
     assert isinstance(exc, ContainerImageError)
+
+def test_container_image_list_tags(mocker):
+    mocker.patch(
+        "image.containerimage.ContainerImageRegistryClient.list_tags",
+        mock_list_tags
+    )
+
+    # Ensure the tag list response matches the expected
+    image = ContainerImage(f"{MOCK_IMAGE_NAME}:latest")
+    tags = image.list_tags(MOCK_REGISTRY_CREDS)
+    assert tags["name"] == MOCK_IMAGE_NAME
+    assert tags["tags"] == [ "latest", "latest-dup", "latest-attestation" ]
 
 def test_container_image_get_manifest(mocker):
     mocker.patch(

--- a/tests/containerimage_test.py
+++ b/tests/containerimage_test.py
@@ -340,7 +340,6 @@ def test_container_image_inspect(mocker):
         "com.example.project.git.url": "https://example.com/project.git",
         "com.example.project.git.commit": "45a939b2999782a3f005621a8d0f29aa387e1d6b"
     }
-    assert inspect.inspect["Author"] == "Alyssa P. Hacker <alyspdev@example.com>"
 
 def test_container_image_is_manifest_list(mocker):
     mocker.patch(

--- a/tests/inspect_test.py
+++ b/tests/inspect_test.py
@@ -1,0 +1,103 @@
+import copy
+import json
+import os
+from image.containerimageinspect import ContainerImageInspect
+from typing import Dict, Any
+
+# Get the directory of this file to load the JSON schemas from files
+WORKDIR = os.path.dirname(os.path.realpath(__file__))
+
+def _load_json(path: str) -> Dict[str, Any]:
+    """
+    Helper function for loading mock manifests
+    """
+    mock_manifest_dict = {}
+    with open(path) as mock_manifest_file:
+        mock_manifest_dict = json.load(mock_manifest_file)
+    return mock_manifest_dict
+
+EXAMPLE_INSPECT = _load_json(f"{WORKDIR}/mock/inspect/inspect.json")
+
+def test_load_skopeo_inspect_output():
+    """
+    Ensure we can load example output from skopeo inspect
+    """
+    exc = None
+    try:
+        inspect = ContainerImageInspect(EXAMPLE_INSPECT)
+    except Exception as e:
+        exc = e
+    assert exc == None
+    assert isinstance(inspect, ContainerImageInspect)
+
+def test_load_inspect_no_labels():
+    """
+    Ensure we can load an inspect output with null labels
+    """
+    example = copy.deepcopy(EXAMPLE_INSPECT)
+    example["Labels"] = None
+    exc = None
+    try:
+        inspect = ContainerImageInspect(example)
+    except Exception as e:
+        exc = e
+    assert exc == None
+    assert isinstance(inspect, ContainerImageInspect)
+
+def test_load_inspect_invalid_name():
+    """
+    Ensure we do not load inspect output with invalid image name
+    """
+    # Invalid name should not work
+    example = copy.deepcopy(EXAMPLE_INSPECT)
+    example["Name"] = "Not a container image"
+    exc = None
+    try:
+        inspect = ContainerImageInspect(example)
+    except Exception as e:
+        exc = e
+    assert exc != None
+
+    # Empty name should work
+    example["Name"] = ""
+    exc = None
+    try:
+        inspect = ContainerImageInspect(example)
+    except Exception as e:
+        exc = e
+    assert exc == None
+    assert isinstance(inspect, ContainerImageInspect)
+
+def test_load_inspect_invalid_digest():
+    """
+    Ensure we do not load inspect output with invalid digests
+    """
+    # Top-level digest
+    example = copy.deepcopy(EXAMPLE_INSPECT)
+    example["Digest"] = "notadigest"
+    exc = None
+    try:
+        inspect = ContainerImageInspect(example)
+    except Exception as e:
+        exc = e
+    assert exc != None
+
+    # Layer digest(s)
+    example = copy.deepcopy(EXAMPLE_INSPECT)
+    example["Layers"][0] = "notadigest"
+    exc = None
+    try:
+        inspect = ContainerImageInspect(example)
+    except Exception as e:
+        exc = e
+    assert exc != None
+
+    # LayersData digest(s)
+    example = copy.deepcopy(EXAMPLE_INSPECT)
+    example["LayersData"][0]["Digest"] = "notadigest"
+    exc = None
+    try:
+        inspect = ContainerImageInspect(example)
+    except Exception as e:
+        exc = e
+    assert exc != None

--- a/tests/mock/configs/config.json
+++ b/tests/mock/configs/config.json
@@ -1,0 +1,56 @@
+{
+    "created": "2015-10-31T22:22:56.015925234Z",
+    "author": "Alyssa P. Hacker <alyspdev@example.com>",
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "User": "alice",
+        "ExposedPorts": {
+            "8080/tcp": {}
+        },
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "FOO=oci_is_a",
+            "BAR=well_written_spec"
+        ],
+        "Entrypoint": [
+            "/bin/my-app-binary"
+        ],
+        "Cmd": [
+            "--foreground",
+            "--config",
+            "/etc/my-app.d/default.cfg"
+        ],
+        "Volumes": {
+            "/var/job-result-data": {},
+            "/var/log/my-app-logs": {}
+        },
+        "WorkingDir": "/home/alice",
+        "Labels": {
+            "com.example.project.git.url": "https://example.com/project.git",
+            "com.example.project.git.commit": "45a939b2999782a3f005621a8d0f29aa387e1d6b"
+        }
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:c6f988f4874bb0add23a778f753c65efe992244e148a1d2ec2a8b664fb66bbd1",
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
+    },
+    "history": [
+      {
+        "created": "2015-10-31T22:22:54.690851953Z",
+        "created_by": "/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /"
+      },
+      {
+        "created": "2015-10-31T22:22:55.613815829Z",
+        "created_by": "/bin/sh -c #(nop) CMD [\"sh\"]",
+        "empty_layer": true
+      },
+      {
+        "created": "2015-10-31T22:22:56.329850019Z",
+        "created_by": "/bin/sh -c apk add curl"
+      }
+    ]
+}

--- a/tests/mock/inspect/inspect.json
+++ b/tests/mock/inspect/inspect.json
@@ -1,0 +1,35 @@
+{
+    "Name": "registry.fedoraproject.org/fedora",
+    "Digest": "sha256:0f65bee641e821f8118acafb44c2f8fe30c2fc6b9a2b3729c0660376391aa117",
+    "RepoTags": [
+        "34-aarch64",
+        "34",
+        "latest"
+    ],
+    "Created": "2022-11-24T13:54:18Z",
+    "DockerVersion": "1.10.1",
+    "Labels": {
+        "license": "MIT",
+        "name": "fedora",
+        "vendor": "Fedora Project",
+        "version": "37"
+    },
+    "Architecture": "amd64",
+    "Os": "linux",
+    "Layers": [
+        "sha256:2a0fc6bf62e155737f0ace6142ee686f3c471c1aab4241dc3128904db46288f0"
+    ],
+    "LayersData": [
+        {
+            "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "Digest": "sha256:2a0fc6bf62e155737f0ace6142ee686f3c471c1aab4241dc3128904db46288f0",
+            "Size": 71355009,
+            "Annotations": null
+        }
+    ],
+    "Env": [
+        "DISTTAG=f37container",
+        "FGC=f37",
+        "container=oci"
+    ]
+}

--- a/tests/registryclientmock.py
+++ b/tests/registryclientmock.py
@@ -3,6 +3,8 @@ import os
 from typing                 import  Any, Dict, Type, Union
 from image.v2s2             import  ContainerImageManifestV2S2
 from image.containerimage   import  ContainerImage
+from image.config           import  ContainerImageConfig
+from image.descriptor       import  ContainerImageDescriptor
 
 """
 ContainerImageRegistryClient mocks
@@ -68,6 +70,11 @@ ATTESTATION_AMD64_ATTESTATION_MANIFEST = _load_mock_manifest(
 )
 ATTESTATION_S390X_ATTESTATION_MANIFEST = _load_mock_manifest(
     f"{WORKDIR}/mock/manifests/attestation-s390x-attestation-manifest.json"
+)
+
+# An example container image config
+MOCK_CONFIG = _load_mock_manifest(
+    f"{WORKDIR}/mock/configs/config.json"
 )
 
 # Mock an image name
@@ -142,6 +149,27 @@ def mock_get_manifest(ref_or_img: Union[str, ContainerImage], auth: Dict[str, An
     elif str(ref_or_img) == f"{MOCK_IMAGE_NAME}@" + \
         "sha256:61d78e5bc2772b75b97fc80f1e796594da4c5421957872be9302b39b1cf155b8":
         return ATTESTATION_S390X_ATTESTATION_MANIFEST
+    else:
+        raise Exception(f"Unmocked reference: {ref_or_img}")
+
+# Mock the ContainerImageRegistryClient.get_config function
+def mock_get_config(
+        ref_or_img: Union[str, ContainerImage],
+        config_desc: ContainerImageDescriptor,
+        auth: Dict[str, Any]
+    ) -> Dict[str, Any]:
+    """
+    Mocks the ContainerImageRegistryClient.get_config function
+
+    Args:
+    ref (Union[str, ContainerImage]): The image reference
+    auth (Dict[str, Any]): The auth for the reference
+
+    Returns:
+    ContainerImageConfig: The container image config
+    """
+    if str(ref_or_img) == f"{MOCK_IMAGE_NAME}:latest":
+        return MOCK_CONFIG
     else:
         raise Exception(f"Unmocked reference: {ref_or_img}")
 

--- a/tests/registryclientmock.py
+++ b/tests/registryclientmock.py
@@ -73,6 +73,16 @@ ATTESTATION_S390X_ATTESTATION_MANIFEST = _load_mock_manifest(
 # Mock an image name
 MOCK_IMAGE_NAME = "this.is/my/registry/and-my-image"
 
+# Mock an image tag list response
+MOCK_TAG_LIST_RESPONSE = {
+    "name": MOCK_IMAGE_NAME,
+    "tags": [
+        "latest",
+        "latest-dup",
+        "latest-attestation"
+    ]
+}
+
 # Mock image registry creds for the above image name mock
 MOCK_REGISTRY_CREDS = {
     "auths": {
@@ -150,3 +160,16 @@ def mock_get_digest(ref_or_img: Union[str, ContainerImage], auth: Dict[str, Any]
         return "sha256:8f74ffc756f871ee9037fb8e0c3cd9c5cb54e92e014f92d771ab8e6bf925f372"
     else:
         raise Exception(f"Unmocked reference: {ref_or_img}")
+
+def mock_list_tags(ref_or_img: Union[str, ContainerImage], auth: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Mocks the ContainerImageRegistryClient.list_tags function
+
+    Args:
+    ref (Union[str, ContainerImage]): The image reference
+    auth (Dict[str, Any]): The auth for the reference
+
+    Returns:
+    Dict[str, Any]: The tag list response
+    """
+    return MOCK_TAG_LIST_RESPONSE


### PR DESCRIPTION
In this PR, I begin to implement a python-native equivalent of `skopeo inspect`.  I develop the following changes in support of this:
- The `ContainerImageInspect` class, which represents the output of `skopeo inspect`
- The `inspectschema.py` source file, with the JSON Schema for validating a `ContainerImageInspect` dict
- In the `ContainerImagePlatform` class, a new static method for getting the host platform
    - With environment variable overrides for the os (`HOST_OS`) and arch (`HOST_ARCH`)
- In the `ContainerImage` class, new methods for
    - Fetching the `ContainerImageConfig` for the image
    - Given a manifest, getting the host platform manifest if it is a manifest list, else raising an exception
    - Using the `ContainerImageConfig` and host platform manifest to construct and return a `ContainerImageInspect` instance

I finally write a new example script `examples/image-inspect.py` to quickly validate this new functionality against a test image.  I am on `darwin/amd64` so to run the example I just simply run the following from the root directory of this repository:
```sh
HOST_OS=linux python3.9 examples/image-inspect.py
```

For reference, see:
- https://github.com/containers/containerimage-py/issues/28