### PR TITLE
fix(validation): do not enforce entry mediatypes

### DIFF
--- a/image/oci.py
+++ b/image/oci.py
@@ -155,10 +155,6 @@ class ContainerImageIndexEntryOCI(ContainerImageManifestListEntry):
             )
             if not platform_valid:
                 return platform_valid, err
-        
-        # If the mediaType is unsupported, then error
-        if entry["mediaType"] in UNSUPPORTED_OCI_MANIFEST_MEDIA_TYPES:
-            return False, f"Unsupported mediaType: {entry['mediaType']}"
 
         # Valid if all of the above are valid
         return True, ""

--- a/image/v2s2.py
+++ b/image/v2s2.py
@@ -18,13 +18,23 @@ from image.v2s2schema           import  MANIFEST_V2_SCHEMA, \
                                         MANIFEST_LIST_V2_SCHEMA, \
                                         MANIFEST_LIST_V2_ENTRY_SCHEMA
 
-# A list of mediaTypes which are not supported by the v2s2 manifest spec
+# See doc comments below
 UNSUPPORTED_V2S2_MANIFEST_MEDIA_TYPES = [
     OCI_MANIFEST_MEDIA_TYPE
 ]
+"""
+A list of mediaTypes which are not supported by the v2s2 manifest spec.
+This mainly just includes the OCI manifest mediaType.
+"""
+
+# See doc comments below
 UNSUPPORTED_V2S2_MANIFEST_LIST_MEDIA_TYPES = [
     OCI_INDEX_MEDIA_TYPE
 ]
+"""
+A list of mediaTypes which are not supported by the v2s2 manifest list
+spec.  This mainly just includes the OCI index mediaType.
+"""
 
 """
 ContainerImageManifestV2S2 class
@@ -145,10 +155,6 @@ class ContainerImageManifestListEntryV2S2(ContainerImageManifestListEntry):
         )
         if not platform_valid:
             return platform_valid, err
-        
-        # If the mediaType is unsupported, then error
-        if entry["mediaType"] in UNSUPPORTED_V2S2_MANIFEST_MEDIA_TYPES:
-            return False, f"Unsupported mediaType: {entry['mediaType']}"
 
         # Valid if all of the above are valid
         return True, ""

--- a/tests/oci_test.py
+++ b/tests/oci_test.py
@@ -96,20 +96,6 @@ OCI_IMAGE_INDEX_EXAMPLE = {
     }
 }
 
-# An example manifest list entry from the CNCF manifest v2s2 spec
-CNCF_MANIFEST_LIST_ENTRY_EXAMPLE = {
-    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
-    "size": 7682,
-    "platform": {
-        "architecture": "amd64",
-        "os": "linux",
-        "features": [
-            "sse4"
-        ]
-    }
-}
-
 # An example image index entry following the OCI spec
 DOCKER_BUILDX_ATTESTATION_INDEX_ENTRY = {
     "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -226,14 +212,6 @@ def test_container_image_oci_image_index_entry_static_validation():
         oci_example_mut
     )
     assert inv_plt_valid == False
-    assert isinstance(err, str)
-    assert len(err) > 0
-
-    # CNCF (non-OCI) example should be invalid
-    cncf_example_valid, err = ContainerImageIndexEntryOCI.validate_static(
-        copy.deepcopy(CNCF_MANIFEST_LIST_ENTRY_EXAMPLE)
-    )
-    assert cncf_example_valid == False
     assert isinstance(err, str)
     assert len(err) > 0
 


### PR DESCRIPTION
In this PR, I soften the check on manifest list entry mediaTypes.  Previously in the v2s2 manifest list and OCI index validation logic I checked the list entries for whether their mediaTypes align with the parent list mediaType.  I.e. if it's a v2s2 manifest list then it better not include OCI manifests, or vice versa.  But it does not seem that the official containerization libraries make this assertation so I am comfortable softening this check.

This eliminates the final blocker for @matejvasek @cmoulliard to use this library to inspect the properties of their base image from `ghcr.io`.

For reference, see:
- https://github.com/containers/containerimage-py/issues/32
- https://github.com/containers/containerimage-py/issues/30