### PR TITLE
doc(inspect): add inspect to quick example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ print(
     f"Digest for {str(my_image)}: " + \
     my_image.get_digest(auth={}) # sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07
 )
+
+# Inspect the container image image for a more consolidated summary
+print(
+    f"Inspect for {str(my_image)}:\n" + \
+    str(my_image.inspect(auth={})) # Same as skopeo inspect docker://registry.k8s.io/pause:3.5
+)
 ```
 
 To run this example, simply execute the following from the root of this repository

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -37,6 +37,12 @@ Here is a quick motivating example for how you might use ``containerimage-py`` i
       my_image.get_digest(auth={}) # sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07
    )
 
+   # Inspect the container image image for a more consolidated summary
+   print(
+      f"Inspect for {str(my_image)}:\n" + \
+      str(my_image.inspect(auth={})) # Same as skopeo inspect docker://registry.k8s.io/pause:3.5
+   )
+
 Installation
 ============
 

--- a/examples/quick-example.py
+++ b/examples/quick-example.py
@@ -17,7 +17,7 @@ sys.path.insert(
 from image.containerimage import ContainerImage
 
 # Initialize a ContainerImage given a tag reference
-my_image = ContainerImage("registry.k8s.io/pause:3.5")
+my_image = ContainerImage("ghcr.io/matejvasek/builder-ubi8-base:latest")
 
 # Display some basic information about the container image
 print(
@@ -27,4 +27,10 @@ print(
 print(
     f"Digest for {str(my_image)}: " + \
     my_image.get_digest(auth={}) # sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07
+)
+
+# Inspect the container image image for a more consolidated summary
+print(
+    f"Inspect for {str(my_image)}:\n" + \
+    str(my_image.inspect(auth={})) # Same as skopeo inspect docker://registry.k8s.io/pause:3.5
 )


### PR DESCRIPTION
In this PR, I add the new `inspect` method on the `ContainerImage` class into the quick example for visibility prior to the `v1.0.0-beta.1` release.

For reference, see:
- https://github.com/containers/containerimage-py/issues/39