### PR TITLE
feat(copy): initial download and copy implementation

### DIFF
--- a/examples/image-copy.py
+++ b/examples/image-copy.py
@@ -1,0 +1,31 @@
+######
+# Hack
+#
+# Make sibling modules visible to this nested executable
+import os, sys
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.realpath(__file__)
+        )
+    )
+)
+# End Hack
+######
+
+SRC_REF = os.environ.get("SRC_REF", "registry.k8s.io/pause:3.5")
+DEST_REF = os.environ.get("DEST_REF")
+
+from image.auth import AUTH
+from image.containerimage import ContainerImage
+
+# Initialize source and dest ContainerImage refs
+src_image = ContainerImage(SRC_REF)
+dest_image = ContainerImage(DEST_REF)
+
+# Copy the source image underneath the dest ref
+src_image.copy(
+    dest_image,
+    auth=AUTH
+)

--- a/examples/image-download.py
+++ b/examples/image-download.py
@@ -1,0 +1,31 @@
+######
+# Hack
+#
+# Make sibling modules visible to this nested executable
+import os, sys
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.realpath(__file__)
+        )
+    )
+)
+# End Hack
+######
+
+DEST_PATH = os.environ.get(
+    "DEST_PATH",
+    os.getcwd()
+)
+
+from image.containerimage import ContainerImage
+
+# Initialize a ContainerImage given a tag reference
+my_image = ContainerImage("registry.k8s.io/pause:3.5")
+
+# Download the image onto your filesystem
+my_image.download(
+    DEST_PATH,
+    auth={}
+)

--- a/image/manifest.py
+++ b/image/manifest.py
@@ -97,7 +97,7 @@ class ContainerImageManifest:
         Returns:
             str: The ContainerImageManifest formatted as a string
         """
-        return json.dumps(self.manifest, indent=2, sort_keys=False)
+        return json.dumps(self.manifest, indent=3, sort_keys=False)
 
     def __json__(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
Implements copy (between registries) and download (registry-to-filesystem) functionality analogous to `skopeo copy`.

For reference, see:
- https://github.com/containers/containerimage-py/issues/12