### PR TITLE
feat(copy): implement registry-to-registry and registry-to-filesystem copy

### DIFF
--- a/examples/image-copy.py
+++ b/examples/image-copy.py
@@ -1,0 +1,31 @@
+######
+# Hack
+#
+# Make sibling modules visible to this nested executable
+import os, sys
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.realpath(__file__)
+        )
+    )
+)
+# End Hack
+######
+
+SRC_REF = os.environ.get("SRC_REF", "registry.k8s.io/pause:3.5")
+DEST_REF = os.environ.get("DEST_REF")
+
+from image.auth import AUTH
+from image.containerimage import ContainerImage
+
+# Initialize source and dest ContainerImage refs
+src_image = ContainerImage(SRC_REF)
+dest_image = ContainerImage(DEST_REF)
+
+# Copy the source image underneath the dest ref
+src_image.copy(
+    dest_image,
+    auth=AUTH
+)

--- a/examples/image-download.py
+++ b/examples/image-download.py
@@ -1,0 +1,31 @@
+######
+# Hack
+#
+# Make sibling modules visible to this nested executable
+import os, sys
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.realpath(__file__)
+        )
+    )
+)
+# End Hack
+######
+
+DEST_PATH = os.environ.get(
+    "DEST_PATH",
+    os.getcwd()
+)
+
+from image.containerimage import ContainerImage
+
+# Initialize a ContainerImage given a tag reference
+my_image = ContainerImage("registry.k8s.io/pause:3.5")
+
+# Download the image onto your filesystem
+my_image.download(
+    DEST_PATH,
+    auth={}
+)

--- a/examples/quick-example.py
+++ b/examples/quick-example.py
@@ -17,7 +17,7 @@ sys.path.insert(
 from image.containerimage import ContainerImage
 
 # Initialize a ContainerImage given a tag reference
-my_image = ContainerImage("ghcr.io/matejvasek/builder-ubi8-base:latest")
+my_image = ContainerImage("registry.k8s.io/pause:3.5")
 
 # Display some basic information about the container image
 print(

--- a/image/containerimage.py
+++ b/image/containerimage.py
@@ -776,7 +776,7 @@ class ContainerImage(ContainerImageReference):
                         layer_upload_url,
                         desc,
                         layer,
-                        auth,
+                        auth=auth,
                         skip_verify=dest_skip_verify,
                         http=dest_http
                     )
@@ -801,7 +801,7 @@ class ContainerImage(ContainerImageReference):
                     config_upload_url,
                     arch_config_desc,
                     arch_config,
-                    auth,
+                    auth=auth,
                     skip_verify=dest_skip_verify,
                     http=dest_http
                 )
@@ -837,7 +837,7 @@ class ContainerImage(ContainerImageReference):
                     layer_upload_url,
                     desc,
                     layer,
-                    auth,
+                    auth=auth,
                     skip_verify=dest_skip_verify,
                     http=dest_http
                 )

--- a/image/containerimage.py
+++ b/image/containerimage.py
@@ -997,9 +997,7 @@ class ContainerImageList:
             str: List size in bytes formatted to nearest unit (ex. "1.23 MB")
         """
         return ByteUnit.format_size_bytes(
-            self.get_size(auth),
-            skip_verify=skip_verify,
-            http=http
+            self.get_size(auth, skip_verify=skip_verify, http=http)
         )
     
     def delete(

--- a/image/containerimage.py
+++ b/image/containerimage.py
@@ -95,7 +95,9 @@ class ContainerImage(ContainerImageReference):
                 ContainerImageManifestOCI,
                 ContainerImageIndexOCI
             ],
-            auth: Dict[str, Any]
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
         ) -> Union[
             ContainerImageManifestV2S2,
             ContainerImageManifestOCI
@@ -109,6 +111,8 @@ class ContainerImage(ContainerImageReference):
             ref (ContainerImageReference): The image reference corresponding to the manifest
             manifest (Union[ContainerImageManifestV2S2,ContainerImageManifestListV2S2,ContainerImageManifestOCI,ContainerImageIndexOCI]): The manifest object, generally from get_manifest method
             auth (Dict[str, Any]): A valid docker config JSON with auth into the ref's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             Union[ContainerImageManifestV2S2,ContainerImageManifestOCI]: The manifest response from the registry API
@@ -136,7 +140,11 @@ class ContainerImage(ContainerImageReference):
             host_ref = ContainerImage(
                 f"{ref.get_name()}@{host_entry_digest}"
             )
-            host_manifest = host_ref.get_manifest(auth=auth)
+            host_manifest = host_ref.get_manifest(
+                auth=auth,
+                skip_verify=skip_verify,
+                http=http
+            )
         
         # Return the manifest matching the host platform
         return host_manifest
@@ -150,7 +158,9 @@ class ContainerImage(ContainerImageReference):
                 ContainerImageManifestOCI,
                 ContainerImageIndexOCI
             ],
-            auth: Dict[str, Any]
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
         ) -> ContainerImageConfig:
         """
         Given an image's manifest, this static method fetches that image's
@@ -162,6 +172,8 @@ class ContainerImage(ContainerImageReference):
             ref (ContainerImageReference): The image reference corresponding to the manifest
             manifest (Union[ContainerImageManifestV2S2,ContainerImageManifestListV2S2,ContainerImageManifestOCI,ContainerImageIndexOCI]): The manifest object, generally from get_manifest method
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             ContainerImageConfig: The config for this image
@@ -171,7 +183,7 @@ class ContainerImage(ContainerImageReference):
         """
         # If manifest list, get the manifest matching the host platform
         manifest = ContainerImage.get_host_platform_manifest_static(
-            ref, manifest, auth
+            ref, manifest, auth, skip_verify=skip_verify, http=http
         )
         
         # Get the image's config
@@ -179,7 +191,9 @@ class ContainerImage(ContainerImageReference):
             ContainerImageRegistryClient.get_config(
                 ref,
                 manifest.get_config_descriptor(),
-                auth=auth
+                auth=auth,
+                skip_verify=skip_verify,
+                http=http
             )
         )
 
@@ -207,22 +221,39 @@ class ContainerImage(ContainerImageReference):
         """
         return ContainerImage.validate_static(self.ref)
     
-    def get_digest(self, auth: Dict[str, Any]) -> str:
+    def get_digest(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> str:
         """
         Parses the digest from the reference if digest reference, or fetches
         it from the registry if tag reference
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             str: The image digest
         """
         if self.is_digest_ref():
             return self.get_identifier()
-        return ContainerImageRegistryClient.get_digest(self, auth)
+        return ContainerImageRegistryClient.get_digest(
+            self,
+            auth,
+            skip_verify=skip_verify,
+            http=http
+        )
     
-    def get_platforms(self, auth: Dict[str, Any]) -> List[
+    def get_platforms(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> List[
             ContainerImagePlatform
         ]:
         """
@@ -231,6 +262,8 @@ class ContainerImage(ContainerImageReference):
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             List[ContainerImagePlatform]: The supported platforms
@@ -243,7 +276,9 @@ class ContainerImage(ContainerImageReference):
             config_dict = ContainerImageRegistryClient.get_config(
                 self,
                 config_desc,
-                auth
+                auth,
+                skip_verify=skip_verify,
+                http=http
             )
             config = ContainerImageConfig(config_dict)
             platforms = [ config.get_platform() ]
@@ -252,7 +287,12 @@ class ContainerImage(ContainerImageReference):
                 platforms.append(entry.get_platform())
         return platforms
 
-    def get_manifest(self, auth: Dict[str, Any]) -> Union[
+    def get_manifest(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> Union[
             ContainerImageManifestV2S2,
             ContainerImageManifestListV2S2,
             ContainerImageManifestOCI,
@@ -263,6 +303,8 @@ class ContainerImage(ContainerImageReference):
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             Union[ContainerImageManifestV2S2,ContainerImageManifestListV2S2,ContainerImageManifestOCI,ContainerImageIndexOCI]: The manifest or manifest list response from the registry API
@@ -274,10 +316,17 @@ class ContainerImage(ContainerImageReference):
         
         # Use the container image registry client to get the manifest
         return ContainerImageManifestFactory.create(
-            ContainerImageRegistryClient.get_manifest(self, auth)
+            ContainerImageRegistryClient.get_manifest(
+                self, auth, skip_verify=skip_verify, http=http
+            )
         )
     
-    def get_host_platform_manifest(self, auth: Dict[str, Any]) -> Union[
+    def get_host_platform_manifest(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> Union[
             ContainerImageManifestOCI,
             ContainerImageManifestV2S2
         ]:
@@ -289,6 +338,8 @@ class ContainerImage(ContainerImageReference):
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             Union[ContainerImageManifestV2S2,ContainerImageManifestOCI]: The manifest response from the registry API
@@ -297,16 +348,27 @@ class ContainerImage(ContainerImageReference):
             ContainerImageError: Error if the image is a manifest list without a manifest matching the host platform
         """
         # Get the container image's manifest
-        manifest = self.get_manifest(auth=auth)
+        manifest = self.get_manifest(
+            auth=auth,
+            skip_verify=skip_verify,
+            http=http
+        )
         
         # Return the host platform manifest
         return ContainerImage.get_host_platform_manifest_static(
             self,
             manifest,
-            auth
+            auth,
+            skip_verify=skip_verify,
+            http=http
         )
 
-    def get_config(self, auth: Dict[str, Any]) -> ContainerImageConfig:
+    def get_config(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> ContainerImageConfig:
         """
         Fetches the image's config from the distribution registry API.  If the
         image is a manifest list, then it gets the config corresponding to the
@@ -314,6 +376,8 @@ class ContainerImage(ContainerImageReference):
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             ContainerImageConfig: The config for this image
@@ -322,41 +386,64 @@ class ContainerImage(ContainerImageReference):
             ContainerImageError: Error if the image is a manifest list without a manifest matching the host platform
         """
         # Get the image's manifest
-        manifest = self.get_manifest(auth=auth)
+        manifest = self.get_manifest(
+            auth=auth,
+            skip_verify=skip_verify,
+            http=http
+        )
 
         # Use the image's manifest to get the image's config
         config = ContainerImage.get_config_static(
-            self, manifest, auth
+            self, manifest, auth, skip_verify=skip_verify, http=http
         )
 
         # Return the image's config
         return config
 
-    def list_tags(self, auth: Dict[str, Any]) -> Dict[str, Any]:
+    def list_tags(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> Dict[str, Any]:
         """
         Fetches the list of tags for the image from the distribution registry
         API.
+
         Args:
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             Dict[str, Any]: The tag list loaded into a dict
         """
-        return ContainerImageRegistryClient.list_tags(self, auth)
+        return ContainerImageRegistryClient.list_tags(
+            self, auth, skip_verify=skip_verify, http=http
+        )
 
-    def exists(self, auth: Dict[str, Any]) -> bool:
+    def exists(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> bool:
         """
         Determine if the image reference corresponds to an image in the remote
         registry.
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             bool: Whether the image exists in the registry
         """
         try:
-            ContainerImageRegistryClient.get_manifest(self, auth)
+            ContainerImageRegistryClient.get_manifest(
+                self, auth, skip_verify=skip_verify, http=http
+            )
         except requests.HTTPError as he:
             if he.response.status_code == 404:
                 return False
@@ -364,99 +451,163 @@ class ContainerImage(ContainerImageReference):
                 raise he
         return True
 
-    def is_manifest_list(self, auth: Dict[str, Any]) -> bool:
+    def is_manifest_list(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> bool:
         """
         Determine if the image is a manifest list
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             bool: Whether the image is a manifest list or single-arch
         """
-        return ContainerImage.is_manifest_list_static(self.get_manifest(auth))
+        return ContainerImage.is_manifest_list_static(
+            self.get_manifest(auth, skip_verify=skip_verify, http=http)
+        )
 
-    def is_oci(self, auth: Dict[str, Any]) -> bool:
+    def is_oci(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> bool:
         """
         Determine if the image is in the OCI format
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON with auth into this image's registry
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             bool: Whether the image is in the OCI format
         """
-        return ContainerImage.is_oci_static(self.get_manifest(auth))
+        return ContainerImage.is_oci_static(
+            self.get_manifest(auth, skip_verify=skip_verify, http=http)
+        )
 
-    def get_media_type(self, auth: Dict[str, Any]) -> str:
+    def get_media_type(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> str:
         """
         Gets the image's mediaType from its manifest
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             str: The image's mediaType
         """
-        return self.get_manifest(auth).get_media_type()
+        return self.get_manifest(
+            auth, skip_verify=skip_verify, http=http
+        ).get_media_type()
 
-    def get_size(self, auth: Dict[str, Any]) -> int:
+    def get_size(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> int:
         """
         Calculates the size of the image by fetching its manifest metadata
         from the registry.
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             int: The size of the image in bytes
         """
         # Get the manifest and calculate its size
-        manifest = self.get_manifest(auth)
+        manifest = self.get_manifest(auth, skip_verify=skip_verify, http=http)
         if ContainerImage.is_manifest_list_static(manifest):
-            return manifest.get_size(self.get_name(), auth)
+            return manifest.get_size(
+                self.get_name(),
+                auth,
+                skip_verify=skip_verify,
+                http=http
+            )
         else:
             return manifest.get_size()
 
-    def get_size_formatted(self, auth: Dict[str, Any]) -> str:
+    def get_size_formatted(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> str:
         """
         Calculates the size of the image by fetching its manifest metadata
         from the registry.  Formats as a human readable string (e.g. 3.14 KB)
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+            skip_verify (bool): Insecure, skip TLS cert verification
 
         Returns:
             str: The size of the image in bytes in human readable format (1.25 GB)
         """
-        return ByteUnit.format_size_bytes(self.get_size(auth))
+        return ByteUnit.format_size_bytes(
+            self.get_size(auth, skip_verify=skip_verify, http=http)
+        )
     
-    def inspect(self, auth: Dict[str, Any]) -> ContainerImageInspect:
+    def inspect(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> ContainerImageInspect:
         """
         Returns a collection of basic information about the image, equivalent
         to skopeo inspect.
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         
         Returns:
             ContainerImageInspect: A collection of information about the image
         """
         # Get the image's manifest
-        manifest = self.get_host_platform_manifest(auth=auth)
+        manifest = self.get_host_platform_manifest(
+            auth=auth,
+            skip_verify=skip_verify,
+            http=http
+        )
 
         # Use the image's manifest to get the image's config
         config = ContainerImage.get_config_static(
-            self, manifest, auth
+            self, manifest, auth, skip_verify=skip_verify, http=http
         )
 
         # List the image's tags
-        tags = self.list_tags(auth)
+        tags = self.list_tags(
+            auth,
+            skip_verify=skip_verify,
+            http=http
+        )
 
         # Format the inspect dictionary
         inspect = {
             "Name": self.get_name(),
-            "Digest": self.get_digest(auth=auth),
+            "Digest": self.get_digest(
+                auth=auth, skip_verify=skip_verify, http=http
+            ),
             "RepoTags": tags["tags"],
             # TODO: Implement v2s1 manifest extension - only v2s1 manifests use this value
             "DockerVersion": "",
@@ -493,7 +644,9 @@ class ContainerImage(ContainerImageReference):
     def download(
             self,
             path: str,
-            auth: Dict[str, Any]
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
         ):
         """
         Downloads the image onto the filesystem
@@ -501,9 +654,13 @@ class ContainerImage(ContainerImageReference):
         Args:
             path (str): The destination path on the filesystem
             auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         """
         # Get the source manifest or manifests
-        manifest = self.get_manifest(auth=auth)
+        manifest = self.get_manifest(
+            auth=auth, skip_verify=skip_verify, http=http
+        )
         if ContainerImage.is_manifest_list_static(manifest):
             for entry in manifest.get_entries():
                 # Create a new ContainerImage for each manifest
@@ -512,7 +669,9 @@ class ContainerImage(ContainerImageReference):
                 )
 
                 # Download each manifest and save as <digest>.manifest.json
-                arch_manifest = manifest_img.get_manifest(auth)
+                arch_manifest = manifest_img.get_manifest(
+                    auth, skip_verify=skip_verify, http=http
+                )
                 with open(
                         f"{path}/{entry.get_digest().split(':')[-1]}.manifest.json", 'w'
                     ) as arch_manifest_file:
@@ -521,7 +680,13 @@ class ContainerImage(ContainerImageReference):
                 # Download each layer and save as <digest>
                 arch_layer_desc = arch_manifest.get_layer_descriptors()
                 for desc in arch_layer_desc:
-                    layer = ContainerImageRegistryClient.get_layer(self, desc, auth)
+                    layer = ContainerImageRegistryClient.get_blob(
+                        self,
+                        desc,
+                        auth,
+                        skip_verify=skip_verify,
+                        http=http
+                    )
                     with open(
                             f"{path}/{desc.get_digest().split(':')[-1]}", 'wb'
                         ) as layer_file:
@@ -530,7 +695,13 @@ class ContainerImage(ContainerImageReference):
             # Download each layer and save as <digest>
             layer_desc = manifest.get_layer_descriptors()
             for desc in layer_desc:
-                layer = ContainerImageRegistryClient.get_layer(self, desc, auth)
+                layer = ContainerImageRegistryClient.get_blob(
+                    self,
+                    desc,
+                    auth,
+                    skip_verify=skip_verify,
+                    http=http
+                )
                 with open(
                         f"{path}/{desc.get_digest().split(':')[-1]}", 'wb'
                     ) as layer_file:
@@ -543,7 +714,11 @@ class ContainerImage(ContainerImageReference):
     def copy(
             self,
             dest: Union[str, ContainerImageReference],
-            auth: Dict[str, Any]
+            auth: Dict[str, Any],
+            src_skip_verify: bool=False,
+            dest_skip_verify: bool=False,
+            src_http: bool=False,
+            dest_http: bool=False
         ):
         """
         Copies the image to a new registry
@@ -551,12 +726,17 @@ class ContainerImage(ContainerImageReference):
         Args:
             dest (Union[str, ContainerImageReference]): The destination location to copy the image
             auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+            src_skip_verify (bool): Insecure, skip TLS cert verification for the source reference
+            dest_skip_verify (bool): Insecure, skip TLS cert verification for the destination reference
+            src_http (bool): Insecure, whether to use HTTP (not HTTPs) for the source reference
+            dest_http (bool): Insecure, whether to use HTTP (not HTTPs) for the destination reference
         """
-        # Initialize a copy in the destination registry
-        upload_id = ContainerImageRegistryClient.initialize_upload(dest, auth)
-        
         # Get the source manifest or manifests
-        manifest = self.get_manifest(auth=auth)
+        manifest = self.get_manifest(
+            auth=auth,
+            skip_verify=src_skip_verify,
+            http=src_http
+        )
         if ContainerImage.is_manifest_list_static(manifest):
             for entry in manifest.get_entries():
                 # Create a new ContainerImage for each manifest
@@ -565,20 +745,40 @@ class ContainerImage(ContainerImageReference):
                 )
 
                 # Download each manifest
-                arch_manifest = manifest_img.get_manifest(auth)
+                arch_manifest = manifest_img.get_manifest(
+                    auth,
+                    skip_verify=src_skip_verify,
+                    http=src_http
+                )
 
                 # Download each layer
                 arch_layer_desc = arch_manifest.get_layer_descriptors()
                 for desc in arch_layer_desc:
-                    layer = ContainerImageRegistryClient.get_blob(self, desc, auth)
+                    layer = ContainerImageRegistryClient.get_blob(
+                        self,
+                        desc,
+                        auth,
+                        skip_verify=src_skip_verify,
+                        http=src_http
+                    )
+
+                    # Initialize a blob upload for the layer
+                    layer_upload_url = ContainerImageRegistryClient.initialize_upload(
+                        dest,
+                        auth,
+                        skip_verify=dest_skip_verify,
+                        http=dest_http
+                    )
 
                     # Upload each layer
                     ContainerImageRegistryClient.upload_blob(
                         dest,
-                        upload_id,
+                        layer_upload_url,
                         desc,
                         layer,
-                        auth
+                        auth,
+                        skip_verify=dest_skip_verify,
+                        http=dest_http
                     )
                 
                 # Download and upload each config
@@ -586,55 +786,93 @@ class ContainerImage(ContainerImageReference):
                 arch_config = ContainerImageRegistryClient.get_blob(
                     self,
                     arch_config_desc,
-                    auth
+                    auth,
+                    skip_verify=src_skip_verify,
+                    http=src_http
+                )
+                config_upload_url = ContainerImageRegistryClient.initialize_upload(
+                    dest,
+                    auth,
+                    skip_verify=dest_skip_verify,
+                    http=dest_http
                 )
                 ContainerImageRegistryClient.upload_blob(
                     dest,
-                    upload_id,
+                    config_upload_url,
                     arch_config_desc,
-                    arch_config
+                    arch_config,
+                    auth,
+                    skip_verify=dest_skip_verify,
+                    http=dest_http
                 )
 
                 # Upload each manifest
                 ContainerImageRegistryClient.upload_manifest(
                     dest,
-                    arch_manifest,
-                    auth
+                    arch_manifest.__json__(),
+                    arch_manifest.get_media_type(),
+                    auth,
+                    skip_verify=dest_skip_verify,
+                    http=dest_http
                 )
         else:
             # Download each layer and save as <digest>
             layer_desc = manifest.get_layer_descriptors()
             for desc in layer_desc:
-                layer = ContainerImageRegistryClient.get_layer(self, desc, auth)
+                layer = ContainerImageRegistryClient.get_blob(
+                    self, desc, auth, skip_verify=src_skip_verify, http=src_http
+                )
+
+                # Initialize a blob upload for the layer
+                layer_upload_url = ContainerImageRegistryClient.initialize_upload(
+                    dest,
+                    auth,
+                    skip_verify=dest_skip_verify,
+                    http=dest_http
+                )
 
                 # Upload each layer
                 ContainerImageRegistryClient.upload_blob(
                     dest,
-                    upload_id,
+                    layer_upload_url,
                     desc,
                     layer,
-                    auth
+                    auth,
+                    skip_verify=dest_skip_verify,
+                    http=dest_http
                 )
         
         # Upload the top-level manifest as manifest.json
         ContainerImageRegistryClient.upload_manifest(
             dest,
-            manifest,
-            auth
+            manifest.__json__(),
+            manifest.get_media_type(),
+            auth,
+            skip_verify=dest_skip_verify,
+            http=dest_http
         )
 
-    def delete(self, auth: Dict[str, Any]):
+    def delete(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ):
         """
         Deletes the image from the registry.
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON loaded into a dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         """
         # Ensure the ref is valid, if not raise an exception
         valid, err = self.validate()
         if not valid:
             raise ContainerImageError(err)
-        ContainerImageRegistryClient.delete(self, auth)
+        ContainerImageRegistryClient.delete(
+            self, auth, skip_verify=skip_verify, http=http
+        )
 
 class ContainerImageList:
     """
@@ -674,12 +912,19 @@ class ContainerImageList:
         """
         self.images.append(image)
 
-    def get_size(self, auth: Dict[str, Any]) -> int:
+    def get_size(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> int:
         """
         Get the deduplicated size of all container images in the list
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             int: The deduplicated size of all container images in the list
@@ -692,15 +937,21 @@ class ContainerImageList:
         # Loop through each image in the list
         for image in self.images:
             # Get the image's manifest
-            manifest = image.get_manifest(auth)
+            manifest = image.get_manifest(
+                auth, skip_verify=skip_verify, http=http
+            )
 
             # If a manifest list, get its configs, entry sizes, layers
             image_layers = []
             image_configs = []
             if ContainerImage.is_manifest_list_static(manifest):
                 entry_sizes += manifest.get_entry_sizes()
-                image_layers = manifest.get_layer_descriptors(image.get_name(), auth)
-                image_configs = manifest.get_config_descriptors(image.get_name(), auth)
+                image_layers = manifest.get_layer_descriptors(
+                    image.get_name(), auth, skip_verify=skip_verify, http=http
+                )
+                image_configs = manifest.get_config_descriptors(
+                    image.get_name(), auth, skip_verify=skip_verify, http=http
+                )
             # If an arch manifest, get its config, layers
             else:
                 image_configs = [manifest.get_config_descriptor()]
@@ -727,28 +978,46 @@ class ContainerImageList:
         # Return the summed size
         return layer_sizes + config_sizes + entry_sizes
     
-    def get_size_formatted(self, auth: Dict[str, Any]) -> str:
+    def get_size_formatted(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> str:
         """
         Get the deduplicated size of all container images in the list,
         formatted as a human readable string (e.g. 3.14 MB)
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             str: List size in bytes formatted to nearest unit (ex. "1.23 MB")
         """
-        return ByteUnit.format_size_bytes(self.get_size(auth))
+        return ByteUnit.format_size_bytes(
+            self.get_size(auth),
+            skip_verify=skip_verify,
+            http=http
+        )
     
-    def delete(self, auth: Dict[str, Any]):
+    def delete(
+            self,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ):
         """
         Delete all of the container images in the list from the registry
 
         Args:
             auth (Dict[str, Any]): A valid docker config JSON dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
         """
         for image in self.images:
-            image.delete(auth)
+            image.delete(auth, skip_verify=skip_verify, http=http)
 
     def diff(self, previous: Type[ContainerImageList]) -> Type[ContainerImageListDiff]:
         """

--- a/image/manifest.py
+++ b/image/manifest.py
@@ -4,7 +4,7 @@ v2s2 and OCI specifications for their respective manifest implementations
 """
 
 import json
-from typing             import  Dict, Any, List, Type
+from typing             import  Dict, Any, List
 from image.descriptor   import  ContainerImageDescriptor
 
 class ContainerImageManifest:

--- a/image/manifest.py
+++ b/image/manifest.py
@@ -97,7 +97,7 @@ class ContainerImageManifest:
         Returns:
             str: The ContainerImageManifest formatted as a string
         """
-        return json.dumps(self.manifest, indent=2, sort_keys=False)
+        return json.dumps(self.manifest, indent=3, sort_keys=False)
 
     def __json__(self) -> Dict[str, Any]:
         """

--- a/image/manifestlist.py
+++ b/image/manifestlist.py
@@ -63,7 +63,13 @@ class ContainerImageManifestList:
             size += entry.get_size()
         return size
 
-    def get_manifests(self, name: str, auth: Dict[str, Any]) -> List[
+    def get_manifests(
+            self,
+            name: str,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> List[
             ContainerImageManifest
         ]:
         """
@@ -72,6 +78,8 @@ class ContainerImageManifestList:
         Args:
             name (str): A valid image name, the name of the manifest
             auth (Dict[str, Any]): A valid docker config JSON dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             List[ContainerImageManifest]: The arch manifests
@@ -91,7 +99,7 @@ class ContainerImageManifestList:
 
             # Get the arch image's manifest from the registry, append to list
             manifest_dict = ContainerImageRegistryClient.get_manifest(
-                ref, auth
+                ref, auth, skip_verify=skip_verify, http=http
             )
             manifest = ContainerImageManifest(manifest_dict)
             manifests.append(manifest)
@@ -99,7 +107,13 @@ class ContainerImageManifestList:
         # Return the list of manifests
         return manifests
 
-    def get_layer_descriptors(self, name: str, auth: Dict[str, Any]) -> List[
+    def get_layer_descriptors(
+            self,
+            name: str,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> List[
             ContainerImageDescriptor
         ]:
         """
@@ -109,19 +123,29 @@ class ContainerImageManifestList:
         Args:
             name (str): A valid image name, the name of the manifest
             auth (Dict[str, Any]): A valid docker config JSON dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             int: The list of layer descriptors across each of the manifests
         """
         layers = []
-        manifests = self.get_manifests(name, auth)
+        manifests = self.get_manifests(
+            name, auth, skip_verify=skip_verify, http=http
+        )
         for manifest in manifests:
             layers.extend(
                 manifest.get_layer_descriptors()
             )
         return layers
 
-    def get_config_descriptors(self, name: str, auth: Dict[str, Any]) -> List[
+    def get_config_descriptors(
+            self,
+            name: str,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> List[
             ContainerImageDescriptor
         ]:
         """
@@ -131,12 +155,16 @@ class ContainerImageManifestList:
         Args:
             name (str): A valid image name, the name of the manifest
             auth (Dict[str, Any]): A valid docker config JSON dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             List[ContainerImageDescriptor]: The list of config descriptors across each of the manifests
         """
         configs = []
-        manifests = self.get_manifests(name, auth)
+        manifests = self.get_manifests(
+            name, auth, skip_verify=skip_verify, http=http
+        )
         for manifest in manifests:
             configs.append(manifest.get_config_descriptor())
         return configs
@@ -150,13 +178,21 @@ class ContainerImageManifestList:
         """
         return str(self.manifest_list.get("mediaType"))
 
-    def get_size(self, name: str, auth: Dict[str, Any]) -> int:
+    def get_size(
+            self,
+            name: str,
+            auth: Dict[str, Any],
+            skip_verify: bool=False,
+            http: bool=False
+        ) -> int:
         """
         Calculates the size of the image using the distribution registry API
 
         Args:
             name (str): A valid image name, the name of the manifest
             auth (Dict[str, Any]): A valid docker config JSON dict
+            skip_verify (bool): Insecure, skip TLS cert verification
+            http (bool): Insecure, whether to use HTTP (not HTTPs)
 
         Returns:
             int: The size of the manifest list in bytes
@@ -181,7 +217,7 @@ class ContainerImageManifestList:
 
             # Get the arch image's manifest from the registry
             manifest_dict = ContainerImageRegistryClient.get_manifest(
-                ref, auth
+                ref, auth, skip_verify=skip_verify, http=http
             )
             manifest = ContainerImageManifest(manifest_dict)
 
@@ -217,7 +253,7 @@ class ContainerImageManifestList:
         Returns:
             str: The ContainerImageManifestListV2S2 formatted as a string
         """
-        return json.dumps(self.manifest_list, indent=2, sort_keys=False)
+        return json.dumps(self.manifest_list, indent=3, sort_keys=False)
 
     def __json__(self) -> Dict[str, Any]:
         """

--- a/image/reference.py
+++ b/image/reference.py
@@ -136,15 +136,23 @@ class ContainerImageReference:
         if not valid:
             raise ContainerImageError(err)
         
+        # Split the domain out of the image path
+        components = self.ref.split("/")
+        domain = components.pop(0)
+        path = "/".join(components)
+        
         # Parse out any digests or tags
-        digestless = self.ref.split("@")[0]
-        tagless = digestless.split(":")[0]
+        digestless_path = path.split("@")[0]
+        tagless_path = digestless_path.split(":")[0]
+
+        # Recombine into a name
+        name = f"{domain}/{tagless_path}"
 
         # Validate the image name, if valid then return
-        valid = bool(re.match(ANCHORED_NAME, tagless))
+        valid = bool(re.match(ANCHORED_NAME, name))
         if not valid:
-            raise ContainerImageError(f"Invalid name: {tagless}")
-        return tagless
+            raise ContainerImageError(f"Invalid name: {name}")
+        return name
 
     def get_registry(self) -> str:
         """

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -121,7 +121,7 @@ def test_container_image_manifest_get_size():
     assert size == expected_size
 
 def test_container_image_manifest_to_string():
-    manifest_str = json.dumps(OCI_MANIFEST_EXAMPLE, indent=2, sort_keys=False)
+    manifest_str = json.dumps(OCI_MANIFEST_EXAMPLE, indent=3, sort_keys=False)
     manifest = ContainerImageManifest(OCI_MANIFEST_EXAMPLE)
     assert str(manifest) == manifest_str
 

--- a/tests/manifestlist_test.py
+++ b/tests/manifestlist_test.py
@@ -110,7 +110,7 @@ def test_container_image_manifest_list_get_size(mocker):
 def test_container_image_manifest_list_to_string():
     # Ensure stringified manifest list matches expected string
     manifest_list_str = json.dumps(
-        CNCF_MANIFEST_LIST_EXAMPLE, indent=2, sort_keys=False
+        CNCF_MANIFEST_LIST_EXAMPLE, indent=3, sort_keys=False
     )
     manifest_list = ContainerImageManifestList(CNCF_MANIFEST_LIST_EXAMPLE)
     assert str(manifest_list) == manifest_list_str

--- a/tests/mock/manifest-lists/attestation-manifest-list.json
+++ b/tests/mock/manifest-lists/attestation-manifest-list.json
@@ -1,50 +1,50 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.index.v1+json",
-    "manifests": [
-        {
-            "mediaType": "application/vnd.oci.image.manifest.v1+json",
-            "digest": "sha256:aa0304d8024783de8537f7e776f33deb57820b853849355b9cbc2a618511521d",
-            "size": 3527,
-            "platform": {
-                "architecture": "amd64",
-                "os": "linux"
-            }
-        },
-        {
-            "mediaType": "application/vnd.oci.image.manifest.v1+json",
-            "digest": "sha256:d06586cc1e3a1f21052c2747237c2394917c8ab7d2e10c284ab975196eff0084",
-            "size": 3527,
-            "platform": {
-                "architecture": "s390x",
-                "os": "linux"
-            }
-        },
-        {
-            "mediaType": "application/vnd.oci.image.manifest.v1+json",
-            "digest": "sha256:171dcd736979ede2a044022fab58b6fa558e5ea9b1486d655d213c688af2c592",
-            "size": 566,
-            "annotations": {
-                "vnd.docker.reference.digest": "sha256:aa0304d8024783de8537f7e776f33deb57820b853849355b9cbc2a618511521d",
-                "vnd.docker.reference.type": "attestation-manifest"
-            },
-            "platform": {
-                "architecture": "unknown",
-                "os": "unknown"
-            }
-        },
-        {
-            "mediaType": "application/vnd.oci.image.manifest.v1+json",
-            "digest": "sha256:61d78e5bc2772b75b97fc80f1e796594da4c5421957872be9302b39b1cf155b8",
-            "size": 566,
-            "annotations": {
-                "vnd.docker.reference.digest": "sha256:d06586cc1e3a1f21052c2747237c2394917c8ab7d2e10c284ab975196eff0084",
-                "vnd.docker.reference.type": "attestation-manifest"
-            },
-            "platform": {
-                "architecture": "unknown",
-                "os": "unknown"
-            }
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.index.v1+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.oci.image.manifest.v1+json",
+         "digest": "sha256:aa0304d8024783de8537f7e776f33deb57820b853849355b9cbc2a618511521d",
+         "size": 3527,
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.oci.image.manifest.v1+json",
+         "digest": "sha256:d06586cc1e3a1f21052c2747237c2394917c8ab7d2e10c284ab975196eff0084",
+         "size": 3527,
+         "platform": {
+            "architecture": "s390x",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.oci.image.manifest.v1+json",
+         "digest": "sha256:171dcd736979ede2a044022fab58b6fa558e5ea9b1486d655d213c688af2c592",
+         "size": 566,
+         "annotations": {
+            "vnd.docker.reference.digest": "sha256:aa0304d8024783de8537f7e776f33deb57820b853849355b9cbc2a618511521d",
+            "vnd.docker.reference.type": "attestation-manifest"
+         },
+         "platform": {
+            "architecture": "unknown",
+            "os": "unknown"
+         }
+      },
+      {
+         "mediaType": "application/vnd.oci.image.manifest.v1+json",
+         "digest": "sha256:61d78e5bc2772b75b97fc80f1e796594da4c5421957872be9302b39b1cf155b8",
+         "size": 566,
+         "annotations": {
+            "vnd.docker.reference.digest": "sha256:d06586cc1e3a1f21052c2747237c2394917c8ab7d2e10c284ab975196eff0084",
+            "vnd.docker.reference.type": "attestation-manifest"
+         },
+         "platform": {
+            "architecture": "unknown",
+            "os": "unknown"
+         }
+      }
+   ]
 }

--- a/tests/mock/manifest-lists/redhat-manifest-list-dup.json
+++ b/tests/mock/manifest-lists/redhat-manifest-list-dup.json
@@ -1,42 +1,42 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-    "manifests": [
-        {
-            "digest": "sha256:058913b247adb61e488c14ee8ab0f5c8022fd08dc945a9d900a02f32effde5c2",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "amd64",
-                "os": "linux"
-            },
-            "size": 429
-        },
-        {
-            "digest": "sha256:96f4394d39e6edb69ca51f000f3e7dfb62990f55868134cfd83c82177651e848",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "arm64",
-                "os": "linux"
-            },
-            "size": 429
-        },
-        {
-            "digest": "sha256:39c59a30e3ecae689c23b27e54a81e03d9a5db22d11890edaf6bb16bac783e8b",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "ppc64le",
-                "os": "linux"
-            },
-            "size": 429
-        },
-        {
-            "digest": "sha256:d187f310724694b1daae2f99f6f86ae05b573eed6826fa40d4233e76bd07312e",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "s390x",
-                "os": "linux"
-            },
-            "size": 429
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+   "manifests": [
+      {
+         "digest": "sha256:058913b247adb61e488c14ee8ab0f5c8022fd08dc945a9d900a02f32effde5c2",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+         },
+         "size": 429
+      },
+      {
+         "digest": "sha256:96f4394d39e6edb69ca51f000f3e7dfb62990f55868134cfd83c82177651e848",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "arm64",
+            "os": "linux"
+         },
+         "size": 429
+      },
+      {
+         "digest": "sha256:39c59a30e3ecae689c23b27e54a81e03d9a5db22d11890edaf6bb16bac783e8b",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "ppc64le",
+            "os": "linux"
+         },
+         "size": 429
+      },
+      {
+         "digest": "sha256:d187f310724694b1daae2f99f6f86ae05b573eed6826fa40d4233e76bd07312e",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "s390x",
+            "os": "linux"
+         },
+         "size": 429
+      }
+   ]
 }

--- a/tests/mock/manifest-lists/redhat-manifest-list.json
+++ b/tests/mock/manifest-lists/redhat-manifest-list.json
@@ -1,42 +1,42 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-    "manifests": [
-        {
-            "digest": "sha256:f5d2c6a1e0c86e4234ea601552dbabb4ced0e013a1efcbfb439f1f6a7a9275b0",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "amd64",
-                "os": "linux"
-            },
-            "size": 429
-        },
-        {
-            "digest": "sha256:96f4394d39e6edb69ca51f000f3e7dfb62990f55868134cfd83c82177651e848",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "arm64",
-                "os": "linux"
-            },
-            "size": 429
-        },
-        {
-            "digest": "sha256:39c59a30e3ecae689c23b27e54a81e03d9a5db22d11890edaf6bb16bac783e8b",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "ppc64le",
-                "os": "linux"
-            },
-            "size": 429
-        },
-        {
-            "digest": "sha256:d187f310724694b1daae2f99f6f86ae05b573eed6826fa40d4233e76bd07312e",
-            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-            "platform": {
-                "architecture": "s390x",
-                "os": "linux"
-            },
-            "size": 429
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+   "manifests": [
+      {
+         "digest": "sha256:f5d2c6a1e0c86e4234ea601552dbabb4ced0e013a1efcbfb439f1f6a7a9275b0",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+         },
+         "size": 429
+      },
+      {
+         "digest": "sha256:96f4394d39e6edb69ca51f000f3e7dfb62990f55868134cfd83c82177651e848",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "arm64",
+            "os": "linux"
+         },
+         "size": 429
+      },
+      {
+         "digest": "sha256:39c59a30e3ecae689c23b27e54a81e03d9a5db22d11890edaf6bb16bac783e8b",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "ppc64le",
+            "os": "linux"
+         },
+         "size": 429
+      },
+      {
+         "digest": "sha256:d187f310724694b1daae2f99f6f86ae05b573eed6826fa40d4233e76bd07312e",
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "platform": {
+            "architecture": "s390x",
+            "os": "linux"
+         },
+         "size": 429
+      }
+   ]
 }

--- a/tests/mock/manifests/attestation-amd64-attestation-manifest.json
+++ b/tests/mock/manifests/attestation-amd64-attestation-manifest.json
@@ -1,19 +1,19 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-    "config": {
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "config": {
       "mediaType": "application/vnd.oci.image.config.v1+json",
       "digest": "sha256:bce70ea4e61e6f02d0795ab117a9239c5e18df224944c97519f885e56b34ec16",
       "size": 167
-    },
-    "layers": [
+   },
+   "layers": [
       {
-        "mediaType": "application/vnd.in-toto+json",
-        "digest": "sha256:2f23945443cac4ee5d19ae5e0f4ad6e3e4e8b3dfa01ad90f8dcc88a425fddea0",
-        "size": 1296,
-        "annotations": {
-          "in-toto.io/predicate-type": "https://slsa.dev/provenance/v0.2"
-        }
+         "mediaType": "application/vnd.in-toto+json",
+         "digest": "sha256:2f23945443cac4ee5d19ae5e0f4ad6e3e4e8b3dfa01ad90f8dcc88a425fddea0",
+         "size": 1296,
+         "annotations": {
+            "in-toto.io/predicate-type": "https://slsa.dev/provenance/v0.2"
+         }
       }
-    ]
-  }
+   ]
+}

--- a/tests/mock/manifests/attestation-amd64-manifest.json
+++ b/tests/mock/manifests/attestation-amd64-manifest.json
@@ -1,26 +1,26 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-    "config": {
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "config": {
       "mediaType": "application/vnd.oci.image.config.v1+json",
       "digest": "sha256:d953a18b298a65c0b0a4026a15d240ee3fa8948fc3b0ebeec4d7f7eeb67ca69f",
       "size": 14781
-    },
-    "layers": [
+   },
+   "layers": [
       {
-        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-        "digest": "sha256:133388727492505cb9d292d14f00942ad2915ab7df3ec1aabbea88cd25035f7b",
-        "size": 39460227
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest": "sha256:133388727492505cb9d292d14f00942ad2915ab7df3ec1aabbea88cd25035f7b",
+         "size": 39460227
       },
       {
-        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-        "digest": "sha256:35cb09b8c00062a78e3f94e9cdfe789d6d246301d150d42a60b01e64f59c09ea",
-        "size": 339
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest": "sha256:35cb09b8c00062a78e3f94e9cdfe789d6d246301d150d42a60b01e64f59c09ea",
+         "size": 339
       },
       {
-        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-        "digest": "sha256:3150b3be4d5a2a6c169c6f47e0104884f7548f1f31e0bf9b20a0b243f5982fab",
-        "size": 4942
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest": "sha256:3150b3be4d5a2a6c169c6f47e0104884f7548f1f31e0bf9b20a0b243f5982fab",
+         "size": 4942
       }
-    ]
-  }
+   ]
+}

--- a/tests/mock/manifests/attestation-s390x-attestation-manifest.json
+++ b/tests/mock/manifests/attestation-s390x-attestation-manifest.json
@@ -1,19 +1,19 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-    "config": {
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "config": {
       "mediaType": "application/vnd.oci.image.config.v1+json",
       "digest": "sha256:84911a2d49ee2e6ee71bff4e03822002ec1f4a72e20442c485be8a73d3eace92",
       "size": 167
-    },
-    "layers": [
+   },
+   "layers": [
       {
-        "mediaType": "application/vnd.in-toto+json",
-        "digest": "sha256:8cfb8feb44ae25023ac7567a1ab203bd3a71daf67bfa6037e6db8a77c9e6dc6f",
-        "size": 1296,
-        "annotations": {
-          "in-toto.io/predicate-type": "https://slsa.dev/provenance/v0.2"
-        }
+         "mediaType": "application/vnd.in-toto+json",
+         "digest": "sha256:8cfb8feb44ae25023ac7567a1ab203bd3a71daf67bfa6037e6db8a77c9e6dc6f",
+         "size": 1296,
+         "annotations": {
+            "in-toto.io/predicate-type": "https://slsa.dev/provenance/v0.2"
+         }
       }
-    ]
-  }
+   ]
+}

--- a/tests/mock/manifests/attestation-s390x-manifest.json
+++ b/tests/mock/manifests/attestation-s390x-manifest.json
@@ -1,26 +1,26 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-    "config": {
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "config": {
       "mediaType": "application/vnd.oci.image.config.v1+json",
       "digest": "sha256:aa7a721d743d125960675e6a3bd94b8e406117349274186257317a633bff7b33",
       "size": 14780
-    },
-    "layers": [
+   },
+   "layers": [
       {
-        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-        "digest": "sha256:8a737b4d6b2dd13e2c6c3f4294a9c6bbe8890676258914a66076064c409c49bd",
-        "size": 37607115
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest": "sha256:8a737b4d6b2dd13e2c6c3f4294a9c6bbe8890676258914a66076064c409c49bd",
+         "size": 37607115
       },
       {
-        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-        "digest": "sha256:35cb09b8c00062a78e3f94e9cdfe789d6d246301d150d42a60b01e64f59c09ea",
-        "size": 339
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest": "sha256:35cb09b8c00062a78e3f94e9cdfe789d6d246301d150d42a60b01e64f59c09ea",
+         "size": 339
       },
       {
-        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-        "digest": "sha256:3150b3be4d5a2a6c169c6f47e0104884f7548f1f31e0bf9b20a0b243f5982fab",
-        "size": 4942
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest": "sha256:3150b3be4d5a2a6c169c6f47e0104884f7548f1f31e0bf9b20a0b243f5982fab",
+         "size": 4942
       }
-    ]
-  }
+   ]
+}

--- a/tests/mock/manifests/redhat-amd64-manifest-dup.json
+++ b/tests/mock/manifests/redhat-amd64-manifest-dup.json
@@ -1,16 +1,16 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "config": {
-        "mediaType": "application/vnd.docker.container.image.v1+json",
-        "size": 5987,
-        "digest": "sha256:2f1ef27bebd5078ab2bd906e20373a30a64b6e97dccfdf7c5af13296790a894c"
-    },
-    "layers": [
-        {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 37786421,
-            "digest": "sha256:258620c3f890940c9b9573d18f5c89465442d9a49af28a2ecf654d38aabdabbd"
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 5987,
+      "digest": "sha256:2f1ef27bebd5078ab2bd906e20373a30a64b6e97dccfdf7c5af13296790a894c"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 37786421,
+         "digest": "sha256:258620c3f890940c9b9573d18f5c89465442d9a49af28a2ecf654d38aabdabbd"
+      }
+   ]
 }

--- a/tests/mock/manifests/redhat-amd64-manifest.json
+++ b/tests/mock/manifests/redhat-amd64-manifest.json
@@ -1,16 +1,16 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "config": {
-        "mediaType": "application/vnd.docker.container.image.v1+json",
-        "size": 6241,
-        "digest": "sha256:dc90caed48cf69bcd1d67dfa6fa1177e91ddcd370f9d2a570d37ea377b23e5b4"
-    },
-    "layers": [
-        {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 39101700,
-            "digest": "sha256:4d5d1cbd7ece41ce278c26338e01e2b82e1861b820ca052da9f3e0b16815358f"
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 6241,
+      "digest": "sha256:dc90caed48cf69bcd1d67dfa6fa1177e91ddcd370f9d2a570d37ea377b23e5b4"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 39101700,
+         "digest": "sha256:4d5d1cbd7ece41ce278c26338e01e2b82e1861b820ca052da9f3e0b16815358f"
+      }
+   ]
 }

--- a/tests/mock/manifests/redhat-arm64-manifest.json
+++ b/tests/mock/manifests/redhat-arm64-manifest.json
@@ -1,16 +1,16 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "config": {
-        "mediaType": "application/vnd.docker.container.image.v1+json",
-        "size": 6244,
-        "digest": "sha256:c8d01adc0698af5cc4b59241a74eb83979b603d62a9c07a1d9e9f956c2fce508"
-    },
-    "layers": [
-        {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 37335414,
-            "digest": "sha256:b7ea02e7115a7f896de4b38813636b60adf943ded0dc88824bbe396f76e618a0"
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 6244,
+      "digest": "sha256:c8d01adc0698af5cc4b59241a74eb83979b603d62a9c07a1d9e9f956c2fce508"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 37335414,
+         "digest": "sha256:b7ea02e7115a7f896de4b38813636b60adf943ded0dc88824bbe396f76e618a0"
+      }
+   ]
 }

--- a/tests/mock/manifests/redhat-ppc64le-manifest.json
+++ b/tests/mock/manifests/redhat-ppc64le-manifest.json
@@ -1,16 +1,16 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "config": {
-        "mediaType": "application/vnd.docker.container.image.v1+json",
-        "size": 6246,
-        "digest": "sha256:ae958797d9140107f0be0be69ed5afae624373086671bd67481dec517cd61572"
-    },
-    "layers": [
-        {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 43591438,
-            "digest": "sha256:e31ac149cb4a1eda22cb8c0e4ae005a8c53c5e2e4fd29c118b346755b642aeb9"
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 6246,
+      "digest": "sha256:ae958797d9140107f0be0be69ed5afae624373086671bd67481dec517cd61572"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 43591438,
+         "digest": "sha256:e31ac149cb4a1eda22cb8c0e4ae005a8c53c5e2e4fd29c118b346755b642aeb9"
+      }
+   ]
 }

--- a/tests/mock/manifests/redhat-s390x-manifest.json
+++ b/tests/mock/manifests/redhat-s390x-manifest.json
@@ -1,16 +1,16 @@
 {
-    "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "config": {
-        "mediaType": "application/vnd.docker.container.image.v1+json",
-        "size": 6236,
-        "digest": "sha256:ffc89b04201adf69c0acd4e94297121e623f9d8a47cccb2aa412bc4b991976fb"
-    },
-    "layers": [
-        {
-            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-            "size": 37364487,
-            "digest": "sha256:9d38740decc88f04976b3123db64216586005286cafbf52d64706fa02375bde9"
-        }
-    ]
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 6236,
+      "digest": "sha256:ffc89b04201adf69c0acd4e94297121e623f9d8a47cccb2aa412bc4b991976fb"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 37364487,
+         "digest": "sha256:9d38740decc88f04976b3123db64216586005286cafbf52d64706fa02375bde9"
+      }
+   ]
 }

--- a/tests/registryclientmock.py
+++ b/tests/registryclientmock.py
@@ -103,7 +103,12 @@ MOCK_REGISTRY_CREDS = {
 }
 
 # Mock the ContainerImageRegistryClient.get_manifest function
-def mock_get_manifest(ref_or_img: Union[str, ContainerImage], auth: Dict[str, Any]) -> Type[
+def mock_get_manifest(
+        ref_or_img: Union[str, ContainerImage],
+        auth: Dict[str, Any],
+        http: bool=False,
+        skip_verify: bool=False
+    ) -> Type[
         ContainerImageManifestV2S2
     ]:
     """
@@ -156,7 +161,9 @@ def mock_get_manifest(ref_or_img: Union[str, ContainerImage], auth: Dict[str, An
 def mock_get_config(
         ref_or_img: Union[str, ContainerImage],
         config_desc: ContainerImageDescriptor,
-        auth: Dict[str, Any]
+        auth: Dict[str, Any],
+        http: bool=False,
+        skip_verify: bool=False
     ) -> Dict[str, Any]:
     """
     Mocks the ContainerImageRegistryClient.get_config function
@@ -173,7 +180,12 @@ def mock_get_config(
     else:
         raise Exception(f"Unmocked reference: {ref_or_img}")
 
-def mock_get_digest(ref_or_img: Union[str, ContainerImage], auth: Dict[str, Any]) -> str:
+def mock_get_digest(
+        ref_or_img: Union[str, ContainerImage],
+        auth: Dict[str, Any],
+        http: bool=False,
+        skip_verify: bool=False
+    ) -> str:
     """
     Mocks the ContainerImageRegistryClient.get_digest function
 
@@ -189,7 +201,12 @@ def mock_get_digest(ref_or_img: Union[str, ContainerImage], auth: Dict[str, Any]
     else:
         raise Exception(f"Unmocked reference: {ref_or_img}")
 
-def mock_list_tags(ref_or_img: Union[str, ContainerImage], auth: Dict[str, Any]) -> Dict[str, Any]:
+def mock_list_tags(
+        ref_or_img: Union[str, ContainerImage],
+        auth: Dict[str, Any],
+        http: bool=False,
+        skip_verify: bool=False
+    ) -> Dict[str, Any]:
     """
     Mocks the ContainerImageRegistryClient.list_tags function
 


### PR DESCRIPTION
Adds two new methods, `copy` and `download` which handle registry-to-registry and registry-to-filesystem copies respectively.

Cherry-pick of:
- https://github.com/containers/containerimage-py/pull/46

For reference, see:
- https://github.com/containers/containerimage-py/issues/12