### PR TITLE
fix(copy): parse www-authenticate header and query params correctly

### DIFF
--- a/image/containerimage.py
+++ b/image/containerimage.py
@@ -715,6 +715,7 @@ class ContainerImage(ContainerImageReference):
             self,
             dest: Union[str, ContainerImageReference],
             auth: Dict[str, Any],
+            chunked: bool=True,
             src_skip_verify: bool=False,
             dest_skip_verify: bool=False,
             src_http: bool=False,
@@ -776,6 +777,7 @@ class ContainerImage(ContainerImageReference):
                         layer_upload_url,
                         desc,
                         layer,
+                        chunked=chunked,
                         auth=auth,
                         skip_verify=dest_skip_verify,
                         http=dest_http
@@ -801,6 +803,7 @@ class ContainerImage(ContainerImageReference):
                     config_upload_url,
                     arch_config_desc,
                     arch_config,
+                    chunked=chunked,
                     auth=auth,
                     skip_verify=dest_skip_verify,
                     http=dest_http
@@ -837,6 +840,7 @@ class ContainerImage(ContainerImageReference):
                     layer_upload_url,
                     desc,
                     layer,
+                    chunked=chunked,
                     auth=auth,
                     skip_verify=dest_skip_verify,
                     http=dest_http


### PR DESCRIPTION
Fixes a bug in which we could not handle `www-authenticate` headers which return a token with `scope=push,pull`.

In the process, I also caught a second bug with how we were formulating the upload URL for the final upload to the private registry.  We were expecting the upload URL to always contain some query parameters on it, and we were appending `<url>&digest=<digest>` naively.  But not all upload URLs contain query parameters by default, so I added safer URL parsing logic using `urllib`.

For reference, see:
- https://github.com/containers/containerimage-py/issues/50