### PR TITLE
chore(release): prepare for 1.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ pip install containerimage-py
 1. Clone this repository
 2. [Build the project from source](#build)
 3. Locate the `.whl` (wheel) file in the `dist` folder
-    - It should be named something like so: `containerimage_py-1.0.0-py3-none-any.whl`
+    - It should be named something like so: `containerimage_py-1.0.1-py3-none-any.whl`
 4. Run the following command from the root of the repository, replacing the name of the `.whl` file if necessary
     ```
-    pip install dist/containerimage_py-1.0.0-py3-none-any.whl
+    pip install dist/containerimage_py-1.0.1-py3-none-any.whl
     ```
 
 ## Build

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,12 +58,12 @@ Run the following command to install the latest version of this package using pi
 
 1. Clone `the source repository <https://github.com/containers/containerimage-py>`_
 2. Build the project from source following `the build instructions <Build_>`_
-3. Locate the ``.whl`` (wheel) file in the ``dist`` folder. It should be named something like so: ``containerimage_py-1.0.0-py3-none-any.whl``
+3. Locate the ``.whl`` (wheel) file in the ``dist`` folder. It should be named something like so: ``containerimage_py-1.0.1-py3-none-any.whl``
 4. Run the following command from the root of the repository, replacing the name of the ``.whl`` file if necessary
 
 .. code-block:: shell
 
-   pip install dist/containerimage_py-1.0.0-py3-none-any.whl
+   pip install dist/containerimage_py-1.0.1-py3-none-any.whl
 
 
 Build


### PR DESCRIPTION
Updates the documentation & README to prepare for the release of containerimage-py v1.0.1